### PR TITLE
Add checkpointing and standardize model exports

### DIFF
--- a/Inference_Engine.py
+++ b/Inference_Engine.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 class InferenceConfig:
     """Configuration for inference engine"""
     # Model settings
-    model_path: str = "./checkpoints/best_model.pth"
+    model_path: str = "./checkpoints/best_model.pt"  # Standardize to .pt
     config_path: str = "./checkpoints/model_config.json"
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
     
@@ -707,7 +707,7 @@ if __name__ == "__main__":
     # Configure inference
     # Note: image_size should match the training configuration (640 for ViT, not 448)
     config = InferenceConfig(
-        model_path="./checkpoints/best_model.pth",
+        model_path="./checkpoints/best_model.pt",  # Standardize to .pt
         config_path="./checkpoints/model_config.json",
         batch_size=32,
         threshold=0.5,
@@ -731,7 +731,7 @@ if __name__ == "__main__":
         'tag_names': vocab.tag_names,
         # ... other checkpoint data
     }
-    torch.save(checkpoint, 'best_model.pth')
+    torch.save(checkpoint, 'best_model.pt')  # Standardize to .pt
     """
 
     # Example of saving model config during training (should be done in training script)

--- a/ONNX_Export.py
+++ b/ONNX_Export.py
@@ -42,7 +42,7 @@ except ImportError:
 
 # Import our modules
 from model_architecture import create_model, VisionTransformerConfig
-from Inference_Engine import load_vocabulary_for_training
+from vocabulary import load_vocabulary_for_training
 
 
 # Configure logging


### PR DESCRIPTION
## Summary
- integrate `CheckpointManager` and `TrainingState` to persist training progress and track best metrics
- add validation loss NaN handling and optional anomaly detection
- standardize model export/import paths to `.pt` and adjust ONNX vocabulary import

## Testing
- `python -m py_compile train_direct.py ONNX_Export.py Inference_Engine.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9d348a3f88321b5230f7981cf1b44