### PR TITLE
Improve training stability and worker initialization

### DIFF
--- a/model_architecture.py
+++ b/model_architecture.py
@@ -199,10 +199,11 @@ class SimplifiedTagger(nn.Module):
                 if attn_kpm is not None:
                     # checkpoint requires tensor args; pass mask explicitly
                     x = torch.utils.checkpoint.checkpoint(
-                        lambda _x, _m: block(_x, key_padding_mask=_m), x, attn_kpm
+                        lambda _x, _m: block(_x, key_padding_mask=_m), x, attn_kpm,
+                        use_reentrant=False
                     )
                 else:
-                    x = torch.utils.checkpoint.checkpoint(block, x)
+                    x = torch.utils.checkpoint.checkpoint(block, x, use_reentrant=False)
             else:
                 x = block(x, key_padding_mask=attn_kpm)
         # Final norm

--- a/training_utils.py
+++ b/training_utils.py
@@ -48,7 +48,7 @@ class TrainingState:
     loss_history: List[float] = field(default_factory=list)
     
     # Metric tracking
-    metrics_history: Dict[str, List[float]] = field(default_factory=lambda: defaultdict(list))
+    metrics_history: Dict[str, List[float]] = field(default_factory=dict)
     learning_rates: List[float] = field(default_factory=list)
     
     # Early stopping
@@ -70,11 +70,15 @@ class TrainingState:
     def update_metrics(self, metrics: Dict[str, float]):
         """Update metrics history"""
         for key, value in metrics.items():
+            if key not in self.metrics_history:
+                self.metrics_history[key] = []
             self.metrics_history[key].append(value)
     
     def to_dict(self) -> Dict:
         """Convert to dictionary for saving"""
-        return asdict(self)
+        # Convert to regular dict to avoid serialization issues
+        data = asdict(self)
+        return data
     
     @classmethod
     def from_dict(cls, data: Dict) -> 'TrainingState':


### PR DESCRIPTION
## Summary
- Fix `TrainingState` metrics history initialization and serialization
- Add non-reentrant checkpointing for gradient checkpointing
- Lower default learning rate, add gradient clipping and NaN checks in training loop
- Harden AMP dtype selection and disable AMP on CPU
- Ensure LMDB environments close once per worker and suppress warnings

## Testing
- `python -m py_compile training_utils.py model_architecture.py train_direct.py HDF5_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9dc191d0483218751fe032989a1b4