### PR TITLE
Stream batch evaluation results to disk

### DIFF
--- a/TEst and review/visualize_results.py
+++ b/TEst and review/visualize_results.py
@@ -1,27 +1,48 @@
  #!/usr/bin/env python3
 import json
+import heapq
 import matplotlib.pyplot as plt
 import numpy as np
 from pathlib import Path
 
-def load_results(results_file):
-    """Load evaluation results from JSON file"""
+
+def load_results(results_file: str):
+    """Load evaluation summary and prepare access to detailed results."""
     with open(results_file, 'r') as f:
         data = json.load(f)
+    if 'results_file' in data:
+        base = Path(results_file).parent
+        data['results_file'] = str(base / data['results_file'])
     return data
+
+
+def detailed_results_iter(results_data):
+    """Yield detailed result entries without loading entire file into memory."""
+    detailed = results_data.get('detailed_results')
+    if detailed is not None:
+        for item in detailed:
+            yield item
+    else:
+        results_file = results_data.get('results_file')
+        if results_file and Path(results_file).exists():
+            with open(results_file, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        yield json.loads(line)
 
 def plot_metrics_distribution(results_data, output_dir):
     """Plot distribution of precision, recall, and F1 scores"""
-    detailed = results_data.get('detailed_results', [])
-    
-    if not detailed:
+    precisions, recalls, f1_scores = [], [], []
+    for r in detailed_results_iter(results_data):
+        metrics = r['metrics']
+        precisions.append(metrics['precision'])
+        recalls.append(metrics['recall'])
+        f1_scores.append(metrics['f1'])
+
+    if not precisions:
         print("No detailed results to plot")
         return
-    
-    # Extract metrics
-    precisions = [r['metrics']['precision'] for r in detailed]
-    recalls = [r['metrics']['recall'] for r in detailed]
-    f1_scores = [r['metrics']['f1'] for r in detailed]
     
     # Create figure with subplots
     fig, axes = plt.subplots(2, 2, figsize=(12, 10))
@@ -122,14 +143,14 @@ def plot_tag_performance(results_data, output_dir, top_n=20):
 
 def plot_tag_counts(results_data, output_dir):
     """Plot distribution of number of tags per image"""
-    detailed = results_data.get('detailed_results', [])
-    
-    if not detailed:
+    gt_counts, pred_counts = [], []
+    for r in detailed_results_iter(results_data):
+        gt_counts.append(r.get('num_gt_tags', len(r.get('ground_truth_tags', []))))
+        pred_counts.append(r.get('num_pred_tags', len(r.get('predicted_tags', []))))
+
+    if not gt_counts:
         print("No detailed results for tag count analysis")
         return
-    
-    gt_counts = [r['num_gt_tags'] for r in detailed]
-    pred_counts = [r['num_pred_tags'] for r in detailed]
     
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
     
@@ -158,14 +179,13 @@ def plot_tag_counts(results_data, output_dir):
 def generate_performance_report(results_data, output_dir):
     """Generate a detailed text report"""
     summary = results_data.get('summary', {})
-    detailed = results_data.get('detailed_results', [])
-    
+
     report_lines = []
     report_lines.append("="*60)
     report_lines.append("MODEL EVALUATION REPORT")
     report_lines.append("="*60)
     report_lines.append("")
-    
+
     # Overall statistics
     report_lines.append("OVERALL STATISTICS:")
     report_lines.append(f"  Total files: {summary.get('total_files', 0)}")
@@ -173,7 +193,7 @@ def generate_performance_report(results_data, output_dir):
     report_lines.append(f"  Failed files: {summary.get('failed_files', 0)}")
     report_lines.append(f"  Threshold: {summary.get('threshold', 0.5)}")
     report_lines.append("")
-    
+
     # Average metrics
     avg_metrics = summary.get('average_metrics', {})
     report_lines.append("AVERAGE METRICS:")
@@ -181,27 +201,51 @@ def generate_performance_report(results_data, output_dir):
     report_lines.append(f"  Recall: {avg_metrics.get('recall', 0):.4f} ± {avg_metrics.get('recall_std', 0):.4f}")
     report_lines.append(f"  F1 Score: {avg_metrics.get('f1', 0):.4f} ± {avg_metrics.get('f1_std', 0):.4f}")
     report_lines.append("")
-    
-    # Performance distribution
-    if detailed:
-        f1_scores = [r['metrics']['f1'] for r in detailed]
+
+    # Performance distribution and top/worst images
+    f1_bins = {"excellent": 0, "good": 0, "fair": 0, "poor": 0}
+    best_heap, worst_heap = [], []
+    any_detail = False
+    for r in detailed_results_iter(results_data):
+        any_detail = True
+        f1 = r['metrics']['f1']
+        if f1 > 0.8:
+            f1_bins["excellent"] += 1
+        elif f1 > 0.6:
+            f1_bins["good"] += 1
+        elif f1 > 0.4:
+            f1_bins["fair"] += 1
+        else:
+            f1_bins["poor"] += 1
+
+        if len(best_heap) < 10:
+            heapq.heappush(best_heap, (f1, r))
+        else:
+            heapq.heappushpop(best_heap, (f1, r))
+
+        if len(worst_heap) < 10:
+            heapq.heappush(worst_heap, (-f1, r))
+        else:
+            heapq.heappushpop(worst_heap, (-f1, r))
+
+    if any_detail:
         report_lines.append("F1 SCORE DISTRIBUTION:")
-        report_lines.append(f"  Excellent (F1 > 0.8): {sum(1 for s in f1_scores if s > 0.8)} images")
-        report_lines.append(f"  Good (0.6 < F1 <= 0.8): {sum(1 for s in f1_scores if 0.6 < s <= 0.8)} images")
-        report_lines.append(f"  Fair (0.4 < F1 <= 0.6): {sum(1 for s in f1_scores if 0.4 < s <= 0.6)} images")
-        report_lines.append(f"  Poor (F1 <= 0.4): {sum(1 for s in f1_scores if s <= 0.4)} images")
+        report_lines.append(f"  Excellent (F1 > 0.8): {f1_bins['excellent']} images")
+        report_lines.append(f"  Good (0.6 < F1 <= 0.8): {f1_bins['good']} images")
+        report_lines.append(f"  Fair (0.4 < F1 <= 0.6): {f1_bins['fair']} images")
+        report_lines.append(f"  Poor (F1 <= 0.4): {f1_bins['poor']} images")
         report_lines.append("")
-    
-    # Best performing files
-    if detailed:
-        sorted_by_f1 = sorted(detailed, key=lambda x: x['metrics']['f1'], reverse=True)
+
+        best_results = [r for _, r in sorted(best_heap, key=lambda x: -x[0])]
+        worst_results = [r for _, r in sorted(worst_heap, key=lambda x: x[0])]
+
         report_lines.append("TOP 10 BEST PERFORMING IMAGES:")
-        for i, result in enumerate(sorted_by_f1[:10], 1):
+        for i, result in enumerate(best_results, 1):
             report_lines.append(f"  {i}. {result['filename']}: F1={result['metrics']['f1']:.3f}")
         report_lines.append("")
-        
+
         report_lines.append("TOP 10 WORST PERFORMING IMAGES:")
-        for i, result in enumerate(sorted_by_f1[-10:], 1):
+        for i, result in enumerate(worst_results, 1):
             report_lines.append(f"  {i}. {result['filename']}: F1={result['metrics']['f1']:.3f}")
         report_lines.append("")
     


### PR DESCRIPTION
## Summary
- Stream individual evaluation results to a JSONL file instead of accumulating them in memory
- Reference the streamed results file in the summary JSON output
- Update visualization utilities to iterate results lazily from disk for large datasets

## Testing
- `python -m py_compile 'TEst and review/batch_evaluate.py' 'TEst and review/visualize_results.py'`


------
https://chatgpt.com/codex/tasks/task_e_68aa06a35d9c8321bf2c10fe5c17409b