### PR TITLE
Improve vocabulary checkpoint and inference handling

### DIFF
--- a/training_utils.py
+++ b/training_utils.py
@@ -522,7 +522,20 @@ class CheckpointManager:
         
         if config is not None:
             checkpoint['config'] = config
-        
+
+        # Save vocabulary info (but not full tag_names to avoid placeholders)
+        if hasattr(model, 'module'):
+            model_to_check = model.module
+        else:
+            model_to_check = model
+
+        if hasattr(model_to_check, 'config'):
+            checkpoint['vocabulary_info'] = {
+                'num_tags': getattr(model_to_check.config, 'num_tags', None),
+                'vocab_path': 'vocabulary.json',
+                'has_vocabulary': True
+            }
+
         # Save regular checkpoint
         checkpoint_path = self.checkpoint_dir / f"checkpoint_epoch_{epoch}_step_{step}.pt"
         torch.save(checkpoint, checkpoint_path)


### PR DESCRIPTION
## Summary
- Save vocabulary metadata and normalization info with checkpoints
- Auto-copy vocabulary file to checkpoint directory during training
- Enhance inference to locate vocab files via multiple search paths and validate placeholder tags

## Testing
- `python -m py_compile train_direct.py Inference_Engine.py training_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa38a87c408321a60cfe28d320e770