### PR TITLE
fix: centralize vocabulary path usage

### DIFF
--- a/HDF5_loader.py
+++ b/HDF5_loader.py
@@ -58,6 +58,10 @@ from vocabulary import TagVocabulary
 
 logger = logging.getLogger(__name__)
 
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_VOCAB_PATH = PROJECT_ROOT / "vocabulary.json"
+
 class BoundedLevelAwareQueue:
     """Bounded queue with level-aware dropping policy for logging."""
     
@@ -2016,7 +2020,7 @@ class SimplifiedDataset(Dataset):
 def create_dataloaders(
     data_dir: Path,
     json_dir: Path,
-    vocab_path: Path,
+    vocab_path: Path = DEFAULT_VOCAB_PATH,
     batch_size: int = 32,
     num_workers: int = 8,
     distributed: bool = False,

--- a/Inference_Engine.py
+++ b/Inference_Engine.py
@@ -55,12 +55,16 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_VOCAB_PATH = PROJECT_ROOT / "vocabulary.json"
+
 
 @dataclass
 class InferenceConfig:
     """Configuration for inference engine"""
     # Model settings
-    vocab_path: Optional[str] = None  # Explicit vocabulary path
+    vocab_path: Optional[str] = str(DEFAULT_VOCAB_PATH)  # Explicit vocabulary path
     model_path: str = "./checkpoints/best_model.pt"  # Standardize to .pt
     config_path: str = "./checkpoints/model_config.json"
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
@@ -206,11 +210,14 @@ class ModelWrapper:
             if self.config.config_path:
                 vocab_search_paths.append(Path(self.config.config_path).parent / "vocabulary.json")
 
-            # 4. Current directory
+            # 4. Project root
+            vocab_search_paths.append(PROJECT_ROOT / "vocabulary.json")
+
+            # 5. Current directory
             vocab_search_paths.append(Path("vocabulary.json"))
 
-            # 5. vocabulary subdirectory
-            vocab_search_paths.append(Path("vocabulary/vocabulary.json"))
+            # 6. vocabulary subdirectory
+            vocab_search_paths.append(PROJECT_ROOT / "vocabulary/vocabulary.json")
 
             vocab_path = None
             for path in vocab_search_paths:

--- a/tag_vocabulary.py
+++ b/tag_vocabulary.py
@@ -27,6 +27,10 @@ from utils.metadata_ingestion import parse_tags_field, dedupe_preserve_order
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_VOCAB_PATH = PROJECT_ROOT / "vocabulary.json"
+
 
 class DanbooruDataPreprocessor:
     """Preprocessor for Danbooru dataset - direct training approach"""
@@ -619,8 +623,8 @@ def main():
     parser.add_argument(
         '--vocab_path',
         type=str,
-        required=True,
-        help='Path to vocabulary directory'
+        default=str(DEFAULT_VOCAB_PATH),
+        help='Path to vocabulary file'
     )
     parser.add_argument(
         '--output_dir',

--- a/train_direct.py
+++ b/train_direct.py
@@ -23,6 +23,10 @@ from torch.amp import GradScaler, autocast
 import numpy as np
 from Monitor_log import MonitorConfig, TrainingMonitor
 
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent
+VOCAB_PATH = PROJECT_ROOT / "vocabulary.json"
+
 # Import the orientation handler
 from orientation_handler import OrientationHandler
 
@@ -189,7 +193,7 @@ def train_with_orientation_tracking():
         "max_grad_norm": 1.0,  # Add gradient clipping
         "data_dir": Path("/media/andrewk/qnap-public/workspace/shard_00022/"),
         "json_dir": Path("/media/andrewk/qnap-public/workspace/shard_00022/"),
-        "vocab_path": Path("vocabulary.json"),
+        "vocab_path": VOCAB_PATH,
         "num_workers": 4,  # Store in config for dataset initialization
         "device": "cuda" if torch.cuda.is_available() else "cpu",
         "checkpoint_dir": Path("checkpoints"),  # Add checkpoint directory
@@ -626,7 +630,7 @@ def train_with_orientation_tracking():
         checkpoint_metadata = {
             "vocabulary_info": {
                 "num_tags": num_tags,
-                "vocab_path": "vocabulary.json",  # Relative to checkpoint dir
+                "vocab_path": str(VOCAB_PATH),
                 "has_vocabulary": True
             },
             "normalization_params": {

--- a/training_utils.py
+++ b/training_utils.py
@@ -33,6 +33,10 @@ import torch.backends.cudnn as cudnn
 
 logger = logging.getLogger(__name__)
 
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent
+VOCAB_PATH = PROJECT_ROOT / "vocabulary.json"
+
 
 @dataclass
 class TrainingState:
@@ -532,7 +536,7 @@ class CheckpointManager:
         if hasattr(model_to_check, 'config'):
             checkpoint['vocabulary_info'] = {
                 'num_tags': getattr(model_to_check.config, 'num_tags', None),
-                'vocab_path': 'vocabulary.json',
+                'vocab_path': str(VOCAB_PATH),
                 'has_vocabulary': True
             }
 

--- a/validation_loop.py
+++ b/validation_loop.py
@@ -56,6 +56,10 @@ from model_architecture import create_model, VisionTransformerConfig
 
 logger = logging.getLogger(__name__)
 
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent
+DEFAULT_VOCAB_PATH = PROJECT_ROOT / "vocabulary.json"
+
 
 @dataclass
 class ValidationConfig:
@@ -65,7 +69,7 @@ class ValidationConfig:
     checkpoint_path: Optional[str] = None
     data_dir: str = "data/images"
     json_dir: str = "data/annotations"
-    vocab_path: str = "vocabulary.json"
+    vocab_path: str = str(DEFAULT_VOCAB_PATH)
     output_dir: str = "./validation_results"
     
     # Validation modes
@@ -138,7 +142,7 @@ class ValidationRunner:
             else:
                 self.vocab = load_vocabulary_for_training(vocab_path)
         else:
-            for path in [Path("vocabulary.json"), Path("vocabulary/vocabulary.json")]:
+            for path in [DEFAULT_VOCAB_PATH, PROJECT_ROOT / "vocabulary/vocabulary.json"]:
                 if path.exists():
                     self.vocab = TagVocabulary(path)
                     break
@@ -995,7 +999,7 @@ def main():
     # Data arguments
     parser.add_argument('--data-dir', type=str, default='data/images')
     parser.add_argument('--json-dir', type=str, default='data/annotations')
-    parser.add_argument('--vocab-path', type=str, default='vocabulary.json')
+    parser.add_argument('--vocab-path', type=str, default=str(DEFAULT_VOCAB_PATH))
     
     # Validation arguments
     parser.add_argument('--mode', type=str, default='full', 

--- a/vocabulary.py
+++ b/vocabulary.py
@@ -14,6 +14,10 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+# Project paths
+PROJECT_ROOT = Path(__file__).resolve().parent
+VOCAB_PATH = PROJECT_ROOT / "vocabulary.json"
+
 # ---------------------------------------------------------------------------
 # Ignore tag handling
 #
@@ -333,7 +337,7 @@ class TagVocabulary:
         return vocab
 
 
-def load_vocabulary_for_training(vocab_dir: Path) -> TagVocabulary:
+def load_vocabulary_for_training(vocab_dir: Path = VOCAB_PATH) -> TagVocabulary:
     """Load vocabulary from directory or file (for backward compatibility).
 
     First tries to load from vocabulary.json, then tags.txt, otherwise
@@ -407,9 +411,9 @@ def create_dataset_config(vocab: TagVocabulary) -> Dict:
 
 def create_vocabulary_from_datasets(dataset_path: Optional[List[Path]] = None):
     """Create vocabulary from datasets (for training).
-    
+
     This function scans the dataset directories for JSON annotation files,
-    builds a vocabulary, and saves it to vocabulary/vocabulary.json.
+    builds a vocabulary, and saves it to the project root ``vocabulary.json``.
     """
     from pathlib import Path
 
@@ -420,13 +424,11 @@ def create_vocabulary_from_datasets(dataset_path: Optional[List[Path]] = None):
 
     vocab = TagVocabulary(min_frequency=5)
     vocab.build_from_annotations([Path(f) for f in json_files], top_k=5000)
-    
-    vocab_dir = Path('vocabulary/')
-    vocab_dir.mkdir(parents=True, exist_ok=True)
-    vocab.save_vocabulary(vocab_dir / 'vocabulary.json')
-    
-    logger.info(f"Created vocabulary with {len(vocab)} tags and saved to {vocab_dir / 'vocabulary.json'}")
-    
+
+    vocab.save_vocabulary(VOCAB_PATH)
+
+    logger.info(f"Created vocabulary with {len(vocab)} tags and saved to {VOCAB_PATH}")
+
     return vocab
 
 


### PR DESCRIPTION
## Summary
- derive project root and vocabulary path in training, validation, and inference modules
- use absolute vocabulary path when creating dataloaders and saving checkpoints
- provide default vocabulary path for dataloader and CLI utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa476ab914832182cb64ca6aae7e6d