### PR TITLE
Embed vocab metadata and add ONNX inference utility

### DIFF
--- a/onnx_infer.py
+++ b/onnx_infer.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""ONNXRuntime inference using embedded vocabulary and preprocessing."""
+import argparse
+import json
+import base64
+import gzip
+import hashlib
+import time
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+import onnxruntime as ort
+
+from vocabulary import TagVocabulary
+
+
+def _load_metadata(session: ort.InferenceSession):
+    meta = session.get_modelmeta().custom_metadata_map
+    if 'vocab_b64_gzip' not in meta:
+        raise RuntimeError('Model is missing embedded vocabulary metadata')
+    vocab_bytes = gzip.decompress(base64.b64decode(meta['vocab_b64_gzip']))
+    sha = hashlib.sha256(vocab_bytes).hexdigest()
+    if meta.get('vocab_sha256') and meta['vocab_sha256'] != sha:
+        raise RuntimeError('Vocabulary checksum mismatch')
+    vocab = TagVocabulary.from_json(vocab_bytes.decode('utf-8'))
+    mean = json.loads(meta.get('normalize_mean', '[0.5, 0.5, 0.5]'))
+    std = json.loads(meta.get('normalize_std', '[0.5, 0.5, 0.5]'))
+    image_size = int(meta.get('image_size', 448))
+    return vocab, mean, std, image_size, meta
+
+
+def _preprocess(image_path: str, image_size: int, mean, std):
+    img = Image.open(image_path).convert('RGB').resize((image_size, image_size))
+    arr = np.array(img).astype('float32') / 255.0
+    arr = (arr - mean) / std
+    arr = arr.transpose(2, 0, 1)[None, :]
+    return arr
+
+
+def main():
+    parser = argparse.ArgumentParser(description='ONNX inference with embedded vocab')
+    parser.add_argument('model', type=str, help='Path to ONNX model')
+    parser.add_argument('images', nargs='+', help='Image paths')
+    parser.add_argument('--top_k', type=int, default=5)
+    parser.add_argument('--threshold', type=float, default=0.0)
+    parser.add_argument('--output', type=str, help='Output JSON file')
+    args = parser.parse_args()
+
+    session = ort.InferenceSession(args.model)
+    vocab, mean, std, image_size, meta = _load_metadata(session)
+    input_name = session.get_inputs()[0].name
+
+    results = []
+    for path in args.images:
+        start = time.time()
+        inp = _preprocess(path, image_size, mean, std)
+        outputs = session.run(None, {input_name: inp})
+        scores = outputs[-1][0]  # assume last output are scores
+        idxs = np.argsort(scores)[::-1][:args.top_k]
+        tags = []
+        for idx in idxs:
+            score = float(scores[idx])
+            if score < args.threshold:
+                continue
+            tags.append({'name': vocab.get_tag_from_index(int(idx)), 'score': score})
+        results.append({
+            'image': path,
+            'tags': tags,
+            'processing_time': int((time.time() - start) * 1000)
+        })
+
+    output = {
+        'metadata': {
+            'top_k': args.top_k,
+            'threshold': args.threshold,
+            'vocab_sha256': meta.get('vocab_sha256', '')
+        },
+        'results': results
+    }
+
+    if args.output:
+        with open(args.output, 'w', encoding='utf-8') as f:
+            json.dump(output, f, indent=2)
+    else:
+        print(json.dumps(output, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/convert_vocab_to_metadata.py
+++ b/scripts/convert_vocab_to_metadata.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Convert vocabulary JSON to compressed metadata for ONNX models."""
+import argparse
+import json
+import base64
+import gzip
+import hashlib
+from pathlib import Path
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert vocabulary to ONNX metadata format")
+    parser.add_argument("vocab", type=str, help="Path to vocabulary.json")
+    parser.add_argument("--output", type=str, help="Optional output file for metadata JSON")
+    args = parser.parse_args()
+
+    vocab_path = Path(args.vocab)
+    with open(vocab_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    json_bytes = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    sha = hashlib.sha256(json_bytes).hexdigest()
+    b64 = base64.b64encode(gzip.compress(json_bytes)).decode("utf-8")
+    metadata = {"vocab_b64_gzip": b64, "vocab_sha256": sha}
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=2)
+    else:
+        print(json.dumps(metadata, indent=2))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Serialize and validate vocabularies with new helper methods, aborting on any placeholder tags
- Embed compressed vocabulary and preprocessing info directly into ONNX models during export
- Add ONNXRuntime inference script and vocab-metadata converter that read embedded mappings and emit standardized results

## Testing
- `python -m py_compile vocabulary.py ONNX_Export.py Inference_Engine.py onnx_infer.py scripts/convert_vocab_to_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa6e0e65a88321aab8ee2d37e5458e