### PR TITLE
Embed vocabulary metadata in checkpoints

### DIFF
--- a/model_metadata.py
+++ b/model_metadata.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Model Metadata Management
+Handles embedding and extraction of vocabulary and preprocessing parameters
+"""
+
+import json
+import gzip
+import base64
+import hashlib
+import logging
+from pathlib import Path
+from typing import Dict, Any, Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class ModelMetadata:
+    """Manages model metadata including vocabulary and preprocessing params"""
+
+    @staticmethod
+    def embed_vocabulary(checkpoint: Dict, vocab_path: Path) -> Dict:
+        """Embed vocabulary into checkpoint
+
+        Args:
+            checkpoint: Checkpoint dictionary to modify
+            vocab_path: Path to vocabulary JSON file
+
+        Returns:
+            Modified checkpoint with embedded vocabulary
+        """
+        if not vocab_path.exists():
+            logger.warning(f"Vocabulary file not found: {vocab_path}")
+            return checkpoint
+
+        try:
+            with open(vocab_path, 'r', encoding='utf-8') as f:
+                vocab_data = json.load(f)
+
+            # Verify vocabulary is valid
+            if 'tag_to_index' not in vocab_data or 'index_to_tag' not in vocab_data:
+                raise ValueError("Invalid vocabulary format")
+
+            # Check for placeholder tags
+            placeholder_count = sum(
+                1 for tag in vocab_data['tag_to_index'].keys()
+                if tag.startswith("tag_") and tag[4:].isdigit()
+            )
+            if placeholder_count > 0:
+                raise ValueError(f"Vocabulary contains {placeholder_count} placeholder tags!")
+
+            # Compress vocabulary
+            vocab_json = json.dumps(vocab_data, ensure_ascii=False)
+            vocab_bytes = vocab_json.encode('utf-8')
+            vocab_compressed = gzip.compress(vocab_bytes)
+            vocab_b64 = base64.b64encode(vocab_compressed).decode('utf-8')
+            vocab_sha256 = hashlib.sha256(vocab_bytes).hexdigest()
+
+            # Embed in checkpoint
+            checkpoint['vocab_b64_gzip'] = vocab_b64
+            checkpoint['vocab_format_version'] = '1'
+            checkpoint['vocab_sha256'] = vocab_sha256
+
+            logger.info(f"Embedded vocabulary with {len(vocab_data['tag_to_index'])} tags")
+            return checkpoint
+
+        except Exception as e:
+            logger.error(f"Failed to embed vocabulary: {e}")
+            return checkpoint
+
+    @staticmethod
+    def extract_vocabulary(checkpoint: Dict) -> Optional[Dict]:
+        """Extract vocabulary from checkpoint
+
+        Args:
+            checkpoint: Checkpoint dictionary
+
+        Returns:
+            Vocabulary data or None if not found
+        """
+        if 'vocab_b64_gzip' not in checkpoint:
+            return None
+
+        try:
+            vocab_b64 = checkpoint['vocab_b64_gzip']
+            vocab_compressed = base64.b64decode(vocab_b64)
+            vocab_bytes = gzip.decompress(vocab_compressed)
+
+            # Verify integrity
+            if 'vocab_sha256' in checkpoint:
+                expected_sha = checkpoint['vocab_sha256']
+                actual_sha = hashlib.sha256(vocab_bytes).hexdigest()
+                if expected_sha != actual_sha:
+                    logger.warning(f"Vocabulary SHA mismatch!")
+
+            vocab_json = vocab_bytes.decode('utf-8')
+            vocab_data = json.loads(vocab_json)
+
+            return vocab_data
+
+        except Exception as e:
+            logger.error(f"Failed to extract vocabulary: {e}")
+            return None
+
+    @staticmethod
+    def embed_preprocessing_params(
+        checkpoint: Dict,
+        normalize_mean: Tuple[float, float, float],
+        normalize_std: Tuple[float, float, float],
+        image_size: int,
+        patch_size: int
+    ) -> Dict:
+        """Embed preprocessing parameters into checkpoint"""
+
+        preprocessing_params = {
+            'normalize_mean': list(normalize_mean),
+            'normalize_std': list(normalize_std),
+            'image_size': image_size,
+            'patch_size': patch_size,
+        }
+
+        checkpoint['preprocessing_params'] = preprocessing_params
+        logger.info(f"Embedded preprocessing params: {preprocessing_params}")
+
+        return checkpoint
+
+    @staticmethod
+    def extract_preprocessing_params(checkpoint: Dict) -> Optional[Dict]:
+        """Extract preprocessing parameters from checkpoint"""
+
+        if 'preprocessing_params' in checkpoint:
+            return checkpoint['preprocessing_params']
+
+        # Try legacy format
+        if 'normalization_params' in checkpoint:
+            legacy = checkpoint['normalization_params']
+            return {
+                'normalize_mean': legacy.get('mean', [0.5, 0.5, 0.5]),
+                'normalize_std': legacy.get('std', [0.5, 0.5, 0.5]),
+                'image_size': checkpoint.get('image_size', 640),
+                'patch_size': checkpoint.get('patch_size', 16),
+            }
+
+        return None
+

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Standard schemas for prediction outputs
+Ensures consistent output format across all tools
+"""
+
+from typing import Dict, List, Any, Optional, Tuple
+from dataclasses import dataclass, asdict
+import json
+
+
+@dataclass
+class TagPrediction:
+    """Single tag prediction"""
+    name: str
+    score: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "score": round(self.score, 4)}
+
+
+@dataclass
+class ImageResult:
+    """Result for a single image"""
+    image: str  # Image path or identifier
+    tags: List[TagPrediction]
+    processing_time: Optional[float] = None  # milliseconds
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "image": self.image,
+            "tags": [t.to_dict() for t in self.tags],
+            "processing_time": round(self.processing_time, 2) if self.processing_time else None
+        }
+
+
+@dataclass
+class RunMetadata:
+    """Metadata for a prediction run"""
+    top_k: int
+    threshold: float
+    vocab_sha256: str
+    normalize_mean: List[float]
+    normalize_std: List[float]
+    image_size: int
+    patch_size: int
+    model_path: Optional[str] = None
+    timestamp: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class PredictionFormatter:
+    """Formats predictions according to standard schema"""
+
+    @staticmethod
+    def format_prediction(
+        image_path: str,
+        predictions: Dict[str, float],
+        processing_time_ms: Optional[float] = None,
+        threshold: float = 0.5
+    ) -> ImageResult:
+        """Format a single prediction"""
+
+        tags = []
+        for tag_name, score in predictions.items():
+            if score >= threshold:
+                tags.append(TagPrediction(name=tag_name, score=score))
+
+        # Sort by score descending
+        tags.sort(key=lambda t: t.score, reverse=True)
+
+        return ImageResult(
+            image=image_path,
+            tags=tags,
+            processing_time=processing_time_ms
+        )
+
+    @staticmethod
+    def format_batch_output(
+        results: List[ImageResult],
+        metadata: RunMetadata
+    ) -> Dict[str, Any]:
+        """Format batch prediction output"""
+
+        return {
+            "metadata": metadata.to_dict(),
+            "results": [r.to_dict() for r in results]
+        }
+
+    @staticmethod
+    def save_results(
+        results: List[ImageResult],
+        metadata: RunMetadata,
+        output_path: str
+    ):
+        """Save results to JSON file"""
+
+        output = PredictionFormatter.format_batch_output(results, metadata)
+
+        with open(output_path, 'w') as f:
+            json.dump(output, f, indent=2)
+
+    @staticmethod
+    def load_results(input_path: str) -> Tuple[List[ImageResult], RunMetadata]:
+        """Load results from JSON file"""
+
+        with open(input_path, 'r') as f:
+            data = json.load(f)
+
+        metadata = RunMetadata(**data['metadata'])
+        results = []
+
+        for r in data['results']:
+            tags = [TagPrediction(**t) for t in r['tags']]
+            results.append(ImageResult(
+                image=r['image'],
+                tags=tags,
+                processing_time=r.get('processing_time')
+            ))
+
+        return results, metadata
+

--- a/scripts/retrofit_checkpoint_vocab.py
+++ b/scripts/retrofit_checkpoint_vocab.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Retrofit existing checkpoints with embedded vocabulary and preprocessing params
+"""
+
+import argparse
+import sys
+from pathlib import Path
+import torch
+import json
+import logging
+from typing import Optional, Tuple
+
+# Add parent directory to path
+sys.path.append(str(Path(__file__).parent.parent))
+
+from model_metadata import ModelMetadata
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def retrofit_checkpoint(
+    checkpoint_path: Path,
+    vocab_path: Path,
+    output_path: Optional[Path] = None,
+    normalize_mean: Tuple[float, float, float] = (0.5, 0.5, 0.5),
+    normalize_std: Tuple[float, float, float] = (0.5, 0.5, 0.5),
+    image_size: int = 640,
+    patch_size: int = 16,
+    force: bool = False
+) -> bool:
+    """Retrofit a checkpoint with embedded vocabulary and preprocessing params"""
+
+    if not checkpoint_path.exists():
+        logger.error(f"Checkpoint not found: {checkpoint_path}")
+        return False
+
+    if not vocab_path.exists():
+        logger.error(f"Vocabulary not found: {vocab_path}")
+        return False
+
+    # Load checkpoint
+    logger.info(f"Loading checkpoint: {checkpoint_path}")
+    checkpoint = torch.load(checkpoint_path, map_location='cpu')
+
+    # Check if already has embedded vocabulary
+    if 'vocab_b64_gzip' in checkpoint and not force:
+        logger.warning("Checkpoint already has embedded vocabulary. Use --force to overwrite.")
+        return False
+
+    # Embed vocabulary
+    checkpoint = ModelMetadata.embed_vocabulary(checkpoint, vocab_path)
+
+    # Embed preprocessing params
+    checkpoint = ModelMetadata.embed_preprocessing_params(
+        checkpoint,
+        normalize_mean,
+        normalize_std,
+        image_size,
+        patch_size
+    )
+
+    # Save retrofitted checkpoint
+    if output_path is None:
+        output_path = checkpoint_path.parent / f"{checkpoint_path.stem}_retrofitted.pt"
+
+    logger.info(f"Saving retrofitted checkpoint: {output_path}")
+    torch.save(checkpoint, output_path)
+
+    # Verify the retrofit
+    logger.info("Verifying retrofitted checkpoint...")
+    test_checkpoint = torch.load(output_path, map_location='cpu')
+
+    vocab_data = ModelMetadata.extract_vocabulary(test_checkpoint)
+    if vocab_data is None:
+        logger.error("Failed to extract vocabulary from retrofitted checkpoint!")
+        return False
+
+    preprocessing = ModelMetadata.extract_preprocessing_params(test_checkpoint)
+    if preprocessing is None:
+        logger.error("Failed to extract preprocessing params from retrofitted checkpoint!")
+        return False
+
+    logger.info(f"✓ Successfully retrofitted checkpoint with:")
+    logger.info(f"  - Vocabulary: {len(vocab_data['tag_to_index'])} tags")
+    logger.info(f"  - Preprocessing: {preprocessing}")
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Retrofit checkpoints with embedded vocabulary')
+    parser.add_argument('checkpoint', type=str, help='Path to checkpoint file')
+    parser.add_argument('vocabulary', type=str, help='Path to vocabulary.json file')
+    parser.add_argument('-o', '--output', type=str, help='Output path (default: adds _retrofitted suffix)')
+    parser.add_argument('--normalize-mean', nargs=3, type=float, default=[0.5, 0.5, 0.5])
+    parser.add_argument('--normalize-std', nargs=3, type=float, default=[0.5, 0.5, 0.5])
+    parser.add_argument('--image-size', type=int, default=640)
+    parser.add_argument('--patch-size', type=int, default=16)
+    parser.add_argument('--force', action='store_true', help='Overwrite existing embedded vocabulary')
+
+    args = parser.parse_args()
+
+    success = retrofit_checkpoint(
+        checkpoint_path=Path(args.checkpoint),
+        vocab_path=Path(args.vocabulary),
+        output_path=Path(args.output) if args.output else None,
+        normalize_mean=tuple(args.normalize_mean),
+        normalize_std=tuple(args.normalize_std),
+        image_size=args.image_size,
+        patch_size=args.patch_size,
+        force=args.force
+    )
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- Embed vocabulary JSON and preprocessing parameters directly into training checkpoints.
- Enhance inference to load embedded vocabularies, verify integrity, and fall back gracefully to external files.
- Add reusable model metadata utilities, retrofit script, and standard output schemas.

## Testing
- `python -m py_compile training_utils.py Inference_Engine.py validation_loop.py model_metadata.py scripts/retrofit_checkpoint_vocab.py schemas.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa7e43f76c8321a2f346843186f62e