### PR TITLE
Add vocabulary integrity checks and update result handling

### DIFF
--- a/Inference_Engine.py
+++ b/Inference_Engine.py
@@ -459,8 +459,13 @@ class ResultProcessor:
             results.append({
                 'image': path,
                 'tags': tags,
-                'processing_time': None  # Will be filled by engine
+                'processing_time': None,  # Will be filled by engine  
             })
+
+            # Validate no placeholder tags in output
+            for tag_dict in tags:
+                if tag_dict['name'].startswith('tag_') and tag_dict['name'][4:].isdigit():
+                    raise ValueError(f"CRITICAL: Placeholder tag '{tag_dict['name']}' in output!")
         
         return results
     
@@ -473,7 +478,10 @@ class ResultProcessor:
             payload = {
                 'metadata': {
                     'top_k': self.config.top_k,
-                    'threshold': self.config.threshold
+                    'threshold': self.config.threshold,
+                    'normalize_mean': list(self.config.normalize_mean),
+                    'normalize_std': list(self.config.normalize_std),
+                    'image_size': self.config.image_size
                 },
                 'results': results
             }

--- a/TEst and review/live_viewer.py
+++ b/TEst and review/live_viewer.py
@@ -16,6 +16,18 @@ import numpy as np
 from typing import Dict, List, Tuple
 
 # Terminal UI version using rich
+def extract_tags_from_result(result):
+    """Extract tags from result, supporting both new and legacy formats."""
+    # Try new schema first
+    if 'tags' in result and isinstance(result['tags'], list):
+        # New schema: tags is a list of {name, score} dicts
+        return {tag['name'] for tag in result['tags']}
+    # Fall back to legacy schema
+    elif 'predicted_tags' in result:
+        return set(result.get('predicted_tags', []))
+    else:
+        return set()
+
 def run_terminal_viewer(jsonl_file: str, refresh_interval: float = 1.0):
     """Terminal-based live viewer using rich library"""
     try:
@@ -131,7 +143,8 @@ def run_terminal_viewer(jsonl_file: str, refresh_interval: float = 1.0):
                     self.stats['zero_f1_count'] += 1
                 
                 # Update tag performance
-                predicted = set(result.get('predicted_tags', []))
+                predicted = extract_tags_from_result(result)
+                # Support both formats for ground truth
                 ground_truth = set(result.get('ground_truth_tags', []))
                 
                 for tag in predicted & ground_truth:
@@ -646,7 +659,8 @@ def run_web_viewer(jsonl_file: str, port: int = 5000):
             })
             
             # Update tag performance
-            predicted = set(result.get('predicted_tags', []))
+            predicted = extract_tags_from_result(result)
+            # Support both formats for ground truth
             ground_truth = set(result.get('ground_truth_tags', []))
             
             for tag in predicted & ground_truth:

--- a/onnx_infer.py
+++ b/onnx_infer.py
@@ -18,12 +18,32 @@ from vocabulary import TagVocabulary
 def _load_metadata(session: ort.InferenceSession):
     meta = session.get_modelmeta().custom_metadata_map
     if 'vocab_b64_gzip' not in meta:
-        raise RuntimeError('Model is missing embedded vocabulary metadata')
+        # Try to load from external vocabulary file as fallback
+        import warnings
+        warnings.warn(
+            "Model is missing embedded vocabulary metadata. "
+            "Attempting to load from external vocabulary.json file. "
+            "For reproducible inference, please use models with embedded vocabulary.",
+            RuntimeWarning
+        )
+        # Return None to signal external vocab needed
+        return None, None, None, None, meta
     vocab_bytes = gzip.decompress(base64.b64decode(meta['vocab_b64_gzip']))
     sha = hashlib.sha256(vocab_bytes).hexdigest()
     if meta.get('vocab_sha256') and meta['vocab_sha256'] != sha:
         raise RuntimeError('Vocabulary checksum mismatch')
     vocab = TagVocabulary.from_json(vocab_bytes.decode('utf-8'))
+
+    # Verify vocabulary integrity
+    placeholder_count = sum(
+        1 for tag in vocab.tag_to_index.keys()
+        if tag.startswith("tag_") and len(tag) > 4 and tag[4:].isdigit()
+    )
+    if placeholder_count > 10:
+        raise RuntimeError(
+            f"Embedded vocabulary contains {placeholder_count} placeholder tags. "
+            f"Model vocabulary is corrupted!"
+        )
     mean = json.loads(meta.get('normalize_mean', '[0.5, 0.5, 0.5]'))
     std = json.loads(meta.get('normalize_std', '[0.5, 0.5, 0.5]'))
     image_size = int(meta.get('image_size', 448))
@@ -45,10 +65,26 @@ def main():
     parser.add_argument('--top_k', type=int, default=5)
     parser.add_argument('--threshold', type=float, default=0.0)
     parser.add_argument('--output', type=str, help='Output JSON file')
+    parser.add_argument('--vocab', type=str, help='External vocabulary file (if not embedded)')
     args = parser.parse_args()
 
     session = ort.InferenceSession(args.model)
-    vocab, mean, std, image_size, meta = _load_metadata(session)
+    result = _load_metadata(session)
+
+    if result[0] is None:
+        # Need to load external vocabulary
+        if not args.vocab:
+            raise RuntimeError(
+                "Model lacks embedded vocabulary and no --vocab file provided. "
+                "Please specify vocabulary with --vocab vocabulary.json"
+            )
+        vocab = TagVocabulary(Path(args.vocab))
+        mean = [0.5, 0.5, 0.5]
+        std = [0.5, 0.5, 0.5]
+        image_size = 448
+        meta = {}
+    else:
+        vocab, mean, std, image_size, meta = result
     input_name = session.get_inputs()[0].name
 
     results = []
@@ -74,7 +110,8 @@ def main():
         'metadata': {
             'top_k': args.top_k,
             'threshold': args.threshold,
-            'vocab_sha256': meta.get('vocab_sha256', '')
+            'vocab_sha256': meta.get('vocab_sha256', ''),
+            'vocab_embedded': 'vocab_b64_gzip' in meta
         },
         'results': results
     }


### PR DESCRIPTION
## Summary
- validate vocabulary and reject placeholder tags across evaluation and inference
- unify result schema with standard tag objects and metadata fields
- allow ONNX inference to fall back to external vocab and record normalization info

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa81e9884c83219cec2c2b732cb681