### PR TITLE
refactor: centralize vocabulary integrity checks

### DIFF
--- a/TEst and review/live_viewer.py
+++ b/TEst and review/live_viewer.py
@@ -15,16 +15,26 @@ import argparse
 import numpy as np
 from typing import Dict, List, Tuple
 
+# Import vocabulary verification
+import sys
+from pathlib import Path as PathLib
+sys.path.append(str(PathLib(__file__).parent.parent))
+from vocabulary import verify_vocabulary_integrity
+
 # Terminal UI version using rich
 def extract_tags_from_result(result):
     """Extract tags from result, supporting both new and legacy formats."""
     # Try new schema first
     if 'tags' in result and isinstance(result['tags'], list):
         # New schema: tags is a list of {name, score} dicts
-        return {tag['name'] for tag in result['tags']}
+        return {tag['name'] for tag in result['tags'] \
+                if not (tag['name'].startswith('tag_') and \
+                       len(tag['name']) > 4 and \
+                       tag['name'][4:].isdigit())}
     # Fall back to legacy schema
     elif 'predicted_tags' in result:
-        return set(result.get('predicted_tags', []))
+        return {tag for tag in result.get('predicted_tags', [])
+                if not (tag.startswith('tag_') and len(tag) > 4 and tag[4:].isdigit())}
     else:
         return set()
 

--- a/TEst and review/visualize_results.py
+++ b/TEst and review/visualize_results.py
@@ -5,15 +5,26 @@ import matplotlib.pyplot as plt
 import numpy as np
 from pathlib import Path
 
+# Import vocabulary verification
+import sys
+sys.path.append(str(Path(__file__).parent.parent))
+from vocabulary import verify_vocabulary_integrity
+
 def extract_tags_from_result(result):
     """Extract predicted tags from result, supporting both new and legacy formats."""
     # Try new schema first
     if 'tags' in result and isinstance(result['tags'], list):
         # New schema: tags is a list of {name, score} dicts
-        return [tag['name'] for tag in result['tags']]
+        # Filter out placeholder tags
+        return [tag['name'] for tag in result['tags']
+                if not (tag['name'].startswith('tag_') and 
+                       len(tag['name']) > 4 and 
+                       tag['name'][4:].isdigit())]
     # Fall back to legacy schema
     elif 'predicted_tags' in result:
-        return result.get('predicted_tags', [])
+        # Filter out placeholder tags
+        return [tag for tag in result.get('predicted_tags', [])
+                if not (tag.startswith('tag_') and len(tag) > 4 and tag[4:].isdigit())]
     else:
         return []
 


### PR DESCRIPTION
## Summary
- add `verify_vocabulary_integrity` helper and alias `_verify_vocabulary_integrity`
- refactor inference, validation, and utility scripts to use centralized verification
- skip placeholder `tag_XXX` entries in outputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa8b6b96808321a72eedcc8e1ea3d7