### PR TITLE
refactor onnx inference output schema

### DIFF
--- a/schemas.py
+++ b/schemas.py
@@ -47,6 +47,7 @@ class RunMetadata:
     patch_size: int
     model_path: Optional[str] = None
     num_tags: Optional[int] = None
+    vocab_embedded: bool = True  # Whether vocab came from model metadata
     
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)


### PR DESCRIPTION
## Summary
- move onnx inference script to use structured schema objects
- return patch size and vocab origin metadata
- add `vocab_embedded` field to `RunMetadata`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa90f11028832183907dcc07ae6e63