### PR TITLE
Fail fast on placeholder tag usage

### DIFF
--- a/TEst and review/live_viewer.py
+++ b/TEst and review/live_viewer.py
@@ -27,14 +27,23 @@ def extract_tags_from_result(result):
     # Try new schema first
     if 'tags' in result and isinstance(result['tags'], list):
         # New schema: tags is a list of {name, score} dicts
-        return {tag['name'] for tag in result['tags'] \
-                if not (tag['name'].startswith('tag_') and \
-                       len(tag['name']) > 4 and \
-                       tag['name'][4:].isdigit())}
+        tags = set()
+        for tag in result['tags']:
+            name = tag['name']
+            # Fail fast on placeholder tags
+            if name.startswith('tag_') and len(name) > 4 and name[4:].isdigit():
+                raise ValueError(f"Placeholder tag '{name}' detected in results. Vocabulary is corrupted.")
+            tags.add(name)
+        return tags
     # Fall back to legacy schema
     elif 'predicted_tags' in result:
-        return {tag for tag in result.get('predicted_tags', [])
-                if not (tag.startswith('tag_') and len(tag) > 4 and tag[4:].isdigit())}
+        tags = set()
+        for tag in result.get('predicted_tags', []):
+            # Fail fast on placeholder tags
+            if tag.startswith('tag_') and len(tag) > 4 and tag[4:].isdigit():
+                raise ValueError(f"Placeholder tag '{tag}' detected in results. Vocabulary is corrupted.")
+            tags.add(tag)
+        return tags
     else:
         return set()
 

--- a/TEst and review/visualize_results.py
+++ b/TEst and review/visualize_results.py
@@ -15,16 +15,23 @@ def extract_tags_from_result(result):
     # Try new schema first
     if 'tags' in result and isinstance(result['tags'], list):
         # New schema: tags is a list of {name, score} dicts
-        # Filter out placeholder tags
-        return [tag['name'] for tag in result['tags']
-                if not (tag['name'].startswith('tag_') and 
-                       len(tag['name']) > 4 and 
-                       tag['name'][4:].isdigit())]
+        tags = []
+        for tag in result['tags']:
+            name = tag['name']
+            # Fail fast on placeholder tags
+            if name.startswith('tag_') and len(name) > 4 and name[4:].isdigit():
+                raise ValueError(f"Placeholder tag '{name}' detected in results. Vocabulary is corrupted.")
+            tags.append(name)
+        return tags
     # Fall back to legacy schema
     elif 'predicted_tags' in result:
-        # Filter out placeholder tags
-        return [tag for tag in result.get('predicted_tags', [])
-                if not (tag.startswith('tag_') and len(tag) > 4 and tag[4:].isdigit())]
+        tags = []
+        for tag in result.get('predicted_tags', []):
+            # Fail fast on placeholder tags
+            if tag.startswith('tag_') and len(tag) > 4 and tag[4:].isdigit():
+                raise ValueError(f"Placeholder tag '{tag}' detected in results. Vocabulary is corrupted.")
+            tags.append(tag)
+        return tags
     else:
         return []
 

--- a/onnx_infer.py
+++ b/onnx_infer.py
@@ -99,10 +99,8 @@ def main():
             score = float(scores[idx])
             if score < args.threshold:
                 continue
+            # This will raise ValueError if placeholder detected
             tag_name = vocab.get_tag_from_index(int(idx))
-            # Skip placeholder tags in output
-            if tag_name.startswith('tag_') and len(tag_name) > 4 and tag_name[4:].isdigit():
-                continue
             tags.append(TagPrediction(name=tag_name, score=score))
 
         results.append(ImagePrediction(

--- a/vocabulary.py
+++ b/vocabulary.py
@@ -174,11 +174,21 @@ class TagVocabulary:
         
         Args:
             index: Tag index
-            
+
         Returns:
             Tag string, or <UNK> if index not found
+            
+        Raises:
+            ValueError: If the tag at the index is a placeholder (corrupted vocabulary)
         """
-        return self.index_to_tag.get(index, self.unk_token)
+        tag = self.index_to_tag.get(index, self.unk_token)
+        # Fail fast if we encounter a placeholder tag
+        if tag != self.unk_token and tag.startswith("tag_") and len(tag) > 4 and tag[4:].isdigit():
+            raise ValueError(
+                f"CRITICAL: Placeholder tag '{tag}' detected at index {index}. "
+                f"The vocabulary is corrupted. Please regenerate from dataset annotations."
+            )
+        return tag
     
     def build_from_annotations(self, json_files: List[Path], top_k: int) -> None:
         """Build a vocabulary from a collection of JSON annotation files.


### PR DESCRIPTION
## Summary
- validate tag indices against vocabulary to detect placeholder tags
- ensure inference and evaluation utilities raise errors when placeholders found
- tighten tag handling in evaluation scripts and ONNX inference

## Testing
- `python -m py_compile vocabulary.py Inference_Engine.py "TEst and review/batch_evaluate.py" "TEst and review/live_viewer.py" "TEst and review/visualize_results.py" onnx_infer.py validation_loop.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68aa921bef088321b35cb80ce64313ae