### PR TITLE
Track image flip status in dataset metadata

### DIFF
--- a/HDF5_loader.py
+++ b/HDF5_loader.py
@@ -1776,6 +1776,7 @@ class SimplifiedDataset(Dataset):
                 if 'gray_background' not in tags:
                     tags.append('gray_background')
 
+            was_flipped = False  # Track if image was flipped
             # Random horizontal flip with orientation-aware tag swapping
             if (
                 self.orientation_handler is not None
@@ -1785,6 +1786,7 @@ class SimplifiedDataset(Dataset):
                 swapped_tags, should_flip = self.orientation_handler.handle_complex_tags(tags)
                 if should_flip:
                     image = TF.hflip(image)
+                    was_flipped = True
                     self._orientation_stats['flips'] += 1
                 else:
                     self._orientation_stats['skipped'] += 1
@@ -1900,6 +1902,7 @@ class SimplifiedDataset(Dataset):
                     'scale': lb_info['scale'],
                     'pad': lb_info['pad'],
                     'was_composited': was_composited,  # Add to metadata for debugging
+                    'was_flipped': was_flipped,  # Track if flip was applied
                 },
             }
         except (IOError, OSError) as e:


### PR DESCRIPTION
## Summary
- Track whether an image was horizontally flipped during loading
- Record flip status in sample metadata for downstream use

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab26a81af48321b2ef1b58dbabed42