### PR TITLE
Streamline ONNX export outputs and preprocessing

### DIFF
--- a/configs/export_config.yaml
+++ b/configs/export_config.yaml
@@ -15,8 +15,7 @@ do_constant_folding: true  # Optimize constants during export
 input_names:
   - input_image
 output_names:
-  - predictions
-  - scores
+  - scores  # Only export scores, not binary predictions (avoids threshold validation issues)
 
 # Dynamic Batching Configuration
 dynamic_batch_size: true  # Allow variable batch sizes
@@ -25,14 +24,18 @@ max_batch_size: 128
 dynamic_axes:  # Define dynamic dimensions
   input_image:
     0: batch_size
-  predictions:
-    0: batch_size
   scores:
     0: batch_size
 
 # Model Architecture Settings
 batch_size: 1  # Default batch size for export
 image_size: 640  # Input image size (must match training)
+
+# Preprocessing Parameters
+# These should match training values - defaults here are ImageNet normalization
+# Will be overridden by values from checkpoint if available
+normalize_mean: [0.485, 0.456, 0.406]  # RGB channel means
+normalize_std: [0.229, 0.224, 0.225]   # RGB channel stds
 
 # Optimization Settings
 optimize: true  # Apply optimization passes

--- a/onnx_infer.py
+++ b/onnx_infer.py
@@ -154,7 +154,13 @@ def main():
         start = time.time()
         inp = _preprocess(path, image_size, mean, std)
         outputs = session.run(None, {input_name: inp})
-        scores = outputs[-1][0]  # assume last output are scores
+
+        # Handle both old (predictions, scores) and new (scores only) model formats
+        if len(outputs) == 1:
+            scores = outputs[0][0]  # New format: scores only
+        else:
+            scores = outputs[-1][0]  # Old format: assume last output are scores
+
         idxs = np.argsort(scores)[::-1][:args.top_k]
         tags = []
         for idx in idxs:


### PR DESCRIPTION
## Summary
- Export only score tensors and drop binary predictions
- Load preprocessing parameters from checkpoints and embed vocab metadata if available
- Fix ONNX Runtime optimizer usage and allow single-output inference

## Testing
- `python -m py_compile ONNX_Export.py onnx_infer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab34003a2483219858c242bd7cd27d