### PR TITLE
Enable epoch-aware weighted sampling

### DIFF
--- a/train_direct.py
+++ b/train_direct.py
@@ -592,6 +592,19 @@ def train_with_orientation_tracking():
         optimizer.zero_grad()
         epoch_start = time.time()
         
+        # CRITICAL: Set epoch for proper shuffling in samplers
+        if hasattr(train_loader, 'sampler') and train_loader.sampler is not None:
+            if hasattr(train_loader.sampler, 'set_epoch'):
+                train_loader.sampler.set_epoch(epoch)
+                logger.info(f"Set epoch {epoch} for sampler {type(train_loader.sampler).__name__}")
+            else:
+                logger.debug(f"Sampler {type(train_loader.sampler).__name__} does not support set_epoch")
+        
+        # Also update dataset epoch if it has working set sampler
+        if hasattr(train_loader.dataset, 'new_epoch'):
+            train_loader.dataset.new_epoch()
+            logger.debug(f"Called new_epoch on dataset for epoch {epoch}")
+        
         # Process any pending augmentation stats from workers
         if stats_queue:
             while not stats_queue.empty():


### PR DESCRIPTION
## Summary
- Add `EpochAwareWeightedSampler` for deterministic yet reshuffled sampling each epoch
- Use new sampler in `create_dataloaders` and seed workers with base seed
- Update training loop to set epoch on sampler and dataset

## Testing
- `python -m py_compile HDF5_loader.py train_direct.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab7e8a01088321afffba9d62950f10