### PR TITLE
Update ONNX opset defaults and improve optimization

### DIFF
--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -694,7 +694,9 @@ class ExportConfig(BaseConfig):
     export_format: str = "onnx"  # onnx, torchscript, tflite, coreml
     
     # ONNX settings
-    opset_version: int = 16
+    # Use opset 18 or higher for transformer models with LayerNormalization
+    # Opset 17 introduced LayerNormalization; opset 18 adds transformer optimizations
+    opset_version: int = 18
     export_params: bool = True
     do_constant_folding: bool = True
     

--- a/configs/export_config.yaml
+++ b/configs/export_config.yaml
@@ -9,7 +9,13 @@ export_variants:  # Which variants to export
   - quantized    # Quantized for size/speed
 
 # ONNX-Specific Settings
-opset_version: 16  # ONNX opset version (16 is widely supported)
+# Use opset 18+ for modern transformer models with LayerNormalization support
+# Opset timeline:
+# - 16 (2021): Basic support, no LayerNormalization
+# - 17 (2022): Added LayerNormalization, GroupNormalization improvements
+# - 18 (2023): Additional optimizations for transformers
+# - 19 (2024): Latest improvements
+opset_version: 18  # Minimum for transformer optimizations with LayerNorm
 export_params: true  # Export model parameters
 do_constant_folding: true  # Optimize constants during export
 input_names:


### PR DESCRIPTION
## Summary
- default to opset 18 for LayerNorm-ready transformers
- add opset-aware optimization with conditional LayerNorm fusions
- ensure ONNX inference preprocessing stays in float32
- document opset timeline in export config

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9507d6048321a64a5d5f3edea1ba