### PR TITLE
Refactor scheduler utilities and training config

### DIFF
--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -466,7 +466,7 @@ class TrainingConfig(BaseConfig):
     # Scheduler
     scheduler: str = "cosine"
     warmup_steps: int = 10000
-    warmup_ratio: float = 0.0  # Alternative to warmup_steps
+    warmup_ratio: float = 0.0  # Deprecated - use warmup_steps directly
     num_cycles: float = 0.5
     lr_end: float = 1e-6
     
@@ -547,7 +547,7 @@ class TrainingConfig(BaseConfig):
         if self.optimizer not in valid_optimizers:
             errors.append(f"Unknown optimizer: {self.optimizer}. Must be one of {valid_optimizers}")
         
-        valid_schedulers = ["linear", "cosine", "constant", "polynomial", "exponential"]
+        valid_schedulers = ["cosine", "cosine_restarts", "step", "multistep", "plateau", "exponential"]
         if self.scheduler not in valid_schedulers:
             errors.append(f"Unknown scheduler: {self.scheduler}. Must be one of {valid_schedulers}")
         

--- a/configs/training_config.yaml
+++ b/configs/training_config.yaml
@@ -14,11 +14,11 @@ adam_beta2: 0.999
 adam_epsilon: 1.0e-8
 
 # Learning Rate Scheduler
-scheduler: cosine  # Options: linear, cosine, constant, polynomial, exponential
-warmup_steps: 10000  # Linear warmup for first 10k steps
-warmup_ratio: 0.0  # Alternative: use ratio of total steps (0.0 means use warmup_steps)
-num_cycles: 0.5  # For cosine scheduler
-lr_end: 1.0e-6  # Minimum learning rate at the end
+scheduler: cosine_restarts  # Options: cosine, cosine_restarts, step, multistep, plateau, exponential
+warmup_steps: 10000  # Linear warmup for first 10k optimizer steps
+# warmup_ratio: 0.0  # Deprecated - use warmup_steps directly
+num_cycles: 1.0  # Number of cosine cycles (for cosine_restarts)
+lr_end: 1.0e-6  # Minimum learning rate
 
 # Mixed Precision Training
 use_amp: true  # Use automatic mixed precision

--- a/train_direct.py
+++ b/train_direct.py
@@ -191,7 +191,6 @@ def train_with_orientation_tracking():
         "gradient_accumulation": 2,
         "num_epochs": 8,
         "warmup_steps": 10_000,
-        "weight_decay": 0.01,
         "label_smoothing": 0.05,
         "max_grad_norm": 1.0,  # Add gradient clipping
         "data_dir": Path("/media/andrewk/qnap-public/workspace/shard_00022/"),
@@ -479,7 +478,7 @@ def train_with_orientation_tracking():
     optimizer = torch.optim.AdamW(
         model.parameters(),
         lr=config["learning_rate"],
-        weight_decay=config["weight_decay"]
+        weight_decay=config.get("weight_decay", 0.0)
     )
 
     # Monitoring setup


### PR DESCRIPTION
## Summary
- drop default weight decay from training script and make optimizer use optional value
- prune unused gradient/scheduler helpers and streamline LearningRateSchedulerFactory
- update training configuration and allowed scheduler list for cosine restarts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abc9f4b3b88321a31de4604ce1b92a