### PR TITLE
refactor: centralize logging configuration

### DIFF
--- a/tag_vocabulary.py
+++ b/tag_vocabulary.py
@@ -9,7 +9,6 @@ import json
 import h5py
 import numpy as np
 import logging
-from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 from collections import Counter
@@ -25,27 +24,9 @@ import yaml
 # Add parent directory to path for imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils.metadata_ingestion import parse_tags_field, dedupe_preserve_order
+from utils.logging_utils import setup_logging
 
-def _setup_logging():
-    try:
-        cfg = yaml.safe_load(Path("configs/logging.yaml").read_text(encoding="utf-8"))
-    except Exception:
-        logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-        return logging.getLogger(__name__)
-    level = getattr(logging, str(cfg.get("level", "INFO")).upper(), logging.INFO)
-    fmt = cfg.get("format", "%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-    logging.basicConfig(level=level, format=fmt)
-    if (cfg.get("file_logging") or {}).get("enabled"):
-        log_dir = Path((cfg.get("file_logging") or {}).get("dir", "./logs"))
-        log_dir.mkdir(parents=True, exist_ok=True)
-        rot = cfg.get("rotation", {}) or {}
-        fh = RotatingFileHandler(log_dir / "tag_vocabulary.log",
-                                 maxBytes=int(rot.get("max_bytes", 10 * 1024 * 1024)),
-                                 backupCount=int(rot.get("backups", 5)))
-        fh.setFormatter(logging.Formatter(fmt))
-        logging.getLogger().addHandler(fh)
-    return logging.getLogger(__name__)
-logger = _setup_logging()
+logger = setup_logging('tag_vocabulary', log_file_name='tag_vocabulary.log')
 
 # Project paths
 PROJECT_ROOT = Path(__file__).resolve().parent

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Utility helpers for consistent logging configuration."""
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+def setup_logging(
+    logger_name: Optional[str] = None,
+    config_path: str | Path = "configs/logging.yaml",
+    log_file_name: Optional[str] = None,
+) -> logging.Logger:
+    """Configure logging using a YAML config file.
+
+    Falls back to a basic configuration if the YAML file cannot be read. When
+    file logging is enabled in the configuration, a :class:`RotatingFileHandler`
+    is attached to the root logger.
+
+    Args:
+        logger_name: Name of the logger to return. ``None`` returns the root
+            logger.
+        config_path: Path to the YAML logging configuration.
+        log_file_name: Optional filename for the rotating log file. If not
+            provided, the ``filename`` from the YAML configuration is used.
+
+    Returns:
+        Configured ``logging.Logger`` instance.
+    """
+    try:
+        cfg = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
+    except Exception:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+        return logging.getLogger(logger_name)
+
+    level = getattr(logging, str(cfg.get("level", "INFO")).upper(), logging.INFO)
+    fmt = cfg.get("format", "%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    logging.basicConfig(level=level, format=fmt)
+
+    file_cfg = cfg.get("file_logging", {}) or {}
+    if file_cfg.get("enabled"):
+        log_dir = Path(file_cfg.get("dir", "./logs"))
+        log_dir.mkdir(parents=True, exist_ok=True)
+        rot = cfg.get("rotation", {}) or {}
+        filename = log_file_name or file_cfg.get("filename", "app.log")
+        handler = RotatingFileHandler(
+            log_dir / filename,
+            maxBytes=int(rot.get("max_bytes", 10 * 1024 * 1024)),
+            backupCount=int(rot.get("backups", 5)),
+        )
+        handler.setFormatter(logging.Formatter(fmt))
+        handler.setLevel(level)
+        logging.getLogger().addHandler(handler)
+
+    return logging.getLogger(logger_name)


### PR DESCRIPTION
## Summary
- add shared logging utility to remove duplicated setup
- switch ONNX and dataset prep scripts to use new logging helper

## Testing
- `python -m py_compile onnx_infer.py tag_vocabulary.py utils/logging_utils.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abee16fde48321a294ccdc8865a671