### PR TITLE
Graceful handling for missing data and weighting options

### DIFF
--- a/Dataset_Analysis.py
+++ b/Dataset_Analysis.py
@@ -209,25 +209,27 @@ class ImageAnalyzer:
         self.config = config
         
     def analyze_image(self, image_path: Path) -> Optional[ImageStats]:
-        """Analyze a single image
-        
+        """Analyze a single image.
+
         Args:
             image_path: Path to image file
-            
+
         Returns:
-            ImageStats object or None if image is corrupted
-            
+            ImageStats object or ``None`` if the image is missing,
+            inaccessible or corrupted.
+
         Raises:
-            FileNotFoundError: If image file doesn't exist
             PermissionError: If file can't be accessed
             RuntimeError: For unexpected errors
         """
         # Check file exists before processing
         if not image_path.exists():
-            raise FileNotFoundError(f"Image file not found: {image_path}")
-        
+            logger.warning("Image file not found: %s", image_path)
+            return None
+
         if not image_path.is_file():
-            raise ValueError(f"Path is not a file: {image_path}")
+            logger.warning("Path is not a file: %s", image_path)
+            return None
         
         try:
             # Get file stats (may raise PermissionError)

--- a/loss_functions.py
+++ b/loss_functions.py
@@ -204,7 +204,11 @@ class FrequencyWeightedSampler:
         elif self.weighting_type == 'log_inverse':
             weights = 1.0 / torch.log(freqs + 1.0)
         else:
-            raise ValueError(f"Unknown weighting_type: {self.weighting_type}")
+            logger.warning(
+                "Unknown weighting_type %s, defaulting to sqrt_inverse",
+                self.weighting_type,
+            )
+            weights = 1.0 / torch.sqrt(freqs)
         weights = weights / weights.max()
         weights = torch.clamp(weights, self.min_weight, self.max_weight)
         return weights


### PR DESCRIPTION
## Summary
- Avoid crashes in dataset analysis by logging and skipping missing or invalid image paths.
- Default to `sqrt_inverse` weighting when sampler receives an unknown weighting type, emitting a warning instead of raising an error.

## Testing
- `python -m py_compile loss_functions.py Dataset_Analysis.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abee2e15888321b9550f105d010d83