### PR TITLE
docs: add configuration guides and comments

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,40 @@
+# OppaiOracle – Configuration Guide
+
+This folder contains all runtime knobs for training, inference, data prep, and exports. Files are plain YAML/JSON so you can commit changes and review diffs.
+
+> **Tip:** If a setting sounds unfamiliar, search this repo for the key name to see where it’s used.
+
+## Files at a glance
+
+- **`training_config.yaml`** – Optimizer, scheduler, checkpoint cadence, distillation, curriculum learning.
+- **`inference_config.yaml`** – How a trained model runs: device, preprocessing, thresholds, output format, API server.
+- **`augmentation.yaml`** – Train‑time augmentations and orientation/flip policy.
+- **`dataset_prep.yaml`** – How we slice and stage the raw dataset for training.
+- **`export_config.yaml`** – ONNX/TensorRT export options and output paths.
+- **`runtime.yaml`** – Determinism and CUDA/cuDNN runtime toggles.
+- **`logging.yaml`** – Log level, file logging, rotation.
+- **`paths.yaml`** – Canonical paths used by scripts (vocab, logs, outputs).
+- **`vocabulary.yaml`** – Token/vocab hygiene: special tokens and frequency cutoffs.
+- **`orientation_map.json`** – Left↔Right mappings and patterns used by flips at train/infer time.
+
+## Common gotchas & invariants
+
+- **Image size vs patch size** – `data.image_size` must be divisible by `data.patch_size`; the model also requires this. If not, training will error or waste pixels.
+- **Effective batch size** – Roughly `batch_size * gradient_accumulation_steps * world_size`. Too large can OOM; see training notes in the file.
+- **Determinism vs speed** – `runtime.deterministic: true` disables some benchmarks; use only when reproducibility is critical.
+- **Normalization & pad color** – Keep `normalize_mean/std` and `pad_color` in inference aligned with training to avoid drops.
+
+## How to override safely
+
+Create a copy of any YAML here and pass its path to the relevant script, or set a small override with an env var or CLI flag if supported. Keep diffs small and focused so they’re easy to review.
+
+## Orientation map docs
+
+See `orientation_map.README.md` in this folder for how flips and symmetric/asymmetric tags are handled.
+
+---
+
+### Changelog
+
+- Added human‑readable comments across configs
+- Added this README and `orientation_map.README.md`

--- a/configs/augmentation.yaml
+++ b/configs/augmentation.yaml
@@ -1,10 +1,10 @@
 # Train-time augmentation & orientation policy
 augmentation:
   enabled: true
-  random_flip_prob: 0.5
+  random_flip_prob: 0.5        # Probability of horizontal flip per image [0..1]
   random_crop_scale: [0.8, 1.0]
   color_jitter:
-    brightness: 0.1
+    brightness: 0.1            # Reasonable range: 0.0–0.4
     contrast:   0.1
     saturation: 0.1
     hue:        0.05
@@ -12,6 +12,6 @@ augmentation:
 
   orientation:
     map_path: "./configs/orientation_map.json"
-    strict_validation: true
+    strict_validation: true     # If true, require a known mapping or regex to flip
     skip_unmapped: false
-    safety_mode: "strict"
+    safety_mode: "strict"       # strict|balanced|lenient – how aggressive to flip

--- a/configs/dataset_prep.yaml
+++ b/configs/dataset_prep.yaml
@@ -1,5 +1,5 @@
 dataset_prep:
-  phase1_size: 4000000
-  total_size: 8500000
-  num_workers: null   # defaults to cpu_count() when null
-  output_dir: "./prepared"
+  phase1_size: 4000000        # First pass subset for coarse filtering/sharding
+  total_size: 8500000         # Overall target size after filtering
+  num_workers: null           # null → use CPU core count; set lower on shared hosts
+  output_dir: "./prepared"    # Where intermediate HDF5/LMDB shards are written

--- a/configs/export_config.yaml
+++ b/configs/export_config.yaml
@@ -1,10 +1,11 @@
 export:
   onnx:
-    opset: 18
-    dynamic_axes: true
+    opset: 18                 # ONNX opset version; 17+ for recent PyTorch ops
+    dynamic_axes: true        # Export with variable batch/sequence dims
   output_dir: "./exports"
   filenames:
     model: "model.onnx"
     quantized: "model.int8.onnx"
   metadata_paths:
     thresholds: "./configs/thresholds.json"
+ # Tip: After export, use onnxruntime to sanity‑check a forward pass.

--- a/configs/inference_config.yaml
+++ b/configs/inference_config.yaml
@@ -1,6 +1,12 @@
 # Inference Configuration for Anime Image Tagger
 # This configuration controls model inference behavior and output formatting
 
+# QUICK NOTES
+# • Keep image_size/normalize_mean/normalize_std identical to training.
+# • If you hit VRAM limits, lower batch_size or set use_fp16:true (CUDA only).
+# • Enable compile_model for speedups on PyTorch 2.x; not all platforms benefit.
+# • API section only matters if running the server mode.
+
 # Model Settings
 model_path: "./checkpoints/best_model.pt"  # Path to trained model checkpoint
 vocab_dir: "./vocabulary"  # Directory containing vocabulary files
@@ -15,9 +21,10 @@ image_size: 640  # Input image size (must match training)
 normalize_mean: [0.5, 0.5, 0.5]  # Anime artwork normalization mean (matches training)
 normalize_std: [0.5, 0.5, 0.5]  # Anime artwork normalization std (matches training)
 pad_color: [114, 114, 114]  # Gray padding color for letterboxing
+ # Note: pad_color must match training/preprocessing to avoid artifacts.
 
 # Prediction Settings
-prediction_threshold: 0.5  # Base threshold for tag predictions
+prediction_threshold: 0.5  # Tags above this probability are returned
 adaptive_threshold: true  # Dynamically adjust threshold based on predictions
 min_predictions: 5  # Minimum number of tags to predict per image
 max_predictions: 50  # Maximum number of tags to predict per image
@@ -40,6 +47,7 @@ apply_implications: true  # Apply tag implications (e.g., cat_ears -> animal_ear
 resolve_aliases: true  # Resolve tag aliases to canonical forms
 group_by_category: false  # Group output tags by category (character, artist, etc.)
 remove_underscores: true  # Replace underscores with spaces in tag names
+ # Tip: For UI outputs, set group_by_category:true and include_scores:true for clarity.
 
 # Performance Settings
 batch_size: 32  # Batch size for processing multiple images
@@ -64,6 +72,7 @@ api_max_image_size: 10485760  # Maximum image size in bytes (10MB)
 api_rate_limit: 100  # Rate limit: requests per minute
 api_cors_origins:  # CORS allowed origins
   - "*"  # Allow all origins (configure properly for production)
+ # In production, replace "*" with a specific list of allowed origins.
 preprocessing:
   image_size: 640
   normalize_mean: [0.5, 0.5, 0.5]

--- a/configs/logging.yaml
+++ b/configs/logging.yaml
@@ -1,8 +1,8 @@
-level: "INFO"
+level: "INFO"                          # DEBUG|INFO|WARNING|ERROR|CRITICAL
 format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 file_logging:
-  enabled: true
+  enabled: true                         # Write logs to files under ./logs
   dir: "./logs"
 rotation:
-  max_bytes: 10485760   # 10 MB
-  backups: 5
+  max_bytes: 10485760                   # Max size per log file before rotation
+  backups: 5                            # How many rotated files to keep

--- a/configs/orientation_map.README.md
+++ b/configs/orientation_map.README.md
@@ -1,0 +1,25 @@
+# Orientation Map – How flips are decided
+
+This JSON is consumed by the augmentation/inference pipeline to translate directional tags when an image is horizontally flipped.
+
+## Sections
+
+- **`explicit_mappings`**: Hard‑coded left↔right pairs (e.g., `left_eye_closed` ↔ `right_eye_closed`).
+- **`regex_patterns`**: Generic patterns to swap left/right substrings in tags.
+- **`symmetric_tags`**: Tags that are visually symmetric; flipping should not change them.
+- **`skip_flip_tags`**: Tags where flipping is unsafe (e.g., any kind of text/watermark).
+- **`complex_asymmetric_tags`**: Tags that need special handling or are only conditionally symmetric (e.g., `heterochromia`).
+
+## Safety levels
+
+The `augmentation.orientation.safety_mode` sets how strictly we require a known mapping before flipping:
+
+- `strict` – Only flip when an explicit mapping or regex applies.
+- `balanced` – Flip using regexes when explicit mapping is missing; skip risky tags.
+- `lenient` – Flip unless a tag appears in `skip_flip_tags`.
+
+## Tips
+
+- When adding new tags, prefer explicit pairs to avoid ambiguity.
+- Keep `skip_flip_tags` conservative; UI/UX labels and watermarks should never be mirrored.
+- If you need inline documentation in JSON, add `_comment` keys beside sections—these are ignored by our loaders but keep the file self‑describing.

--- a/configs/paths.yaml
+++ b/configs/paths.yaml
@@ -1,4 +1,4 @@
-vocab_path: "./vocabulary.json"          # Absolute or repo-relative path to vocabulary.json
-log_dir: "./logs"
-default_output_dir: "./outputs"
-orientation_map_path: "configs/orientation_map.json"
+vocab_path: "./vocabulary.json"     # Absolute or repo‑relative path to vocabulary.json
+log_dir: "./logs"                   # Where logs and summaries are written
+default_output_dir: "./outputs"     # Default artifact/exports folder
+orientation_map_path: "configs/orientation_map.json"  # Flip mapping for augment/infer

--- a/configs/runtime.yaml
+++ b/configs/runtime.yaml
@@ -1,5 +1,5 @@
 runtime:
-  deterministic: false
-  cublas_workspace_config: ":16:8"
-  cudnn_benchmark: true
-  quiet_mode: false
+  deterministic: false            # True makes runs repeatable; slightly slower
+  cublas_workspace_config: ":16:8" # Repro preset for CUDA; leave unless you know why
+  cudnn_benchmark: true           # Auto‑tune convs for current shapes (disable if deterministic)
+  quiet_mode: false               # Reduce console logs where supported

--- a/configs/training_config.yaml
+++ b/configs/training_config.yaml
@@ -1,6 +1,18 @@
 # Training Configuration for Anime Image Tagger
 # This configuration is for training a 1B parameter model with dual teacher distillation
 
+# ──────────────────────────────────────────────────────────────────────────────
+# QUICK START (safe knobs)
+# • num_epochs: Total passes over data. Increase for better convergence; watch val loss.
+# • learning_rate: Start at 1e-4 for AdamW; lower if you see divergence.
+# • gradient_accumulation_steps: Multiplies effective batch size without more GPU RAM.
+# • scheduler: Use `cosine_restarts` for long runs; `cosine` is simpler.
+# • use_amp/amp_dtype: Mixed precision (`bfloat16` on Ampere+ is stable) → faster/less RAM.
+# • save_steps/eval_steps/logging_steps: I/O cadence; larger values = fewer disk writes.
+# • distributed/world_size/ddp_backend: Multi‑GPU; keep `nccl` on Linux with CUDA.
+# • deterministic vs benchmark: determinism disables autotune; enable only when comparing runs.
+# ──────────────────────────────────────────────────────────────────────────────
+
 # Basic Training Settings
 num_epochs: 100
 learning_rate: 1.0e-4  # Base learning rate for AdamW
@@ -15,25 +27,25 @@ adam_epsilon: 1.0e-8
 
 # Learning Rate Scheduler
 scheduler: cosine_restarts  # Options: cosine, cosine_restarts, step, multistep, plateau, exponential
-warmup_steps: 10000  # Linear warmup for first 10k optimizer steps
+warmup_steps: 10000         # Steps to ramp LR from 0→base; prevents early instability
 # warmup_ratio: 0.0  # Deprecated - use warmup_steps directly
-num_cycles: 1.0  # Number of cosine cycles (for cosine_restarts)
-lr_end: 1.0e-6  # Minimum learning rate
+num_cycles: 1.0             # For cosine_restarts only; 1.0 = one full cycle
+lr_end: 1.0e-6              # Floor LR (useful to keep tiny updates late in training)
 
 # Mixed Precision Training
-use_amp: true  # Use automatic mixed precision
-amp_opt_level: O1  # Options: O0, O1, O2, O3
-amp_dtype: bfloat16  # Options: float16, bfloat16
+use_amp: true              # Enable AMP to speed up and reduce memory footprint
+amp_opt_level: O1          # Legacy naming; keep O1 unless using Apex explicitly
+amp_dtype: bfloat16        # Prefer bfloat16 on Ampere+ GPUs; use float16 otherwise
 
 # Gradient Clipping
 max_grad_norm: 1.0  # Maximum gradient norm for clipping
 
 # Checkpointing Strategy
-save_steps: 10000  # Save checkpoint every N steps
-save_total_limit: 3  # Keep only the last N checkpoints
-save_best_only: false  # Save all checkpoints, not just the best
-eval_steps: 1000  # Run validation every N steps
-logging_steps: 100  # Log metrics every N steps
+save_steps: 10000        # How often to write checkpoints
+save_total_limit: 3      # Max checkpoints to retain → controls disk usage
+save_best_only: false    # Set true to keep only best per val metric
+eval_steps: 1000         # Validation cadence (tradeoff speed vs signal)
+logging_steps: 100       # Metric/console logging cadence
 
 # Loss Configuration - Asymmetric Focal Loss
 focal_gamma_pos: 0.0  # Gamma for positive samples (0 = no focal weighting)
@@ -44,40 +56,40 @@ label_smoothing: 0.1  # Label smoothing factor
 use_class_weights: true  # Use frequency-based class weights
 
 # Knowledge Distillation from Dual Teachers
-use_distillation: false
-distillation_alpha: 0.7  # Weight for distillation loss vs ground truth
-distillation_temperature: 3.0  # Temperature for soft targets
-anime_teacher_weight: 0.7  # Weight for anime teacher (70k tags model)
-clip_teacher_weight: 0.3  # Weight for CLIP teacher
+use_distillation: false             # Enable to blend teacher logits with labels
+distillation_alpha: 0.7             # 0=only labels, 1=only teachers
+distillation_temperature: 3.0       # Higher = softer probability targets
+anime_teacher_weight: 0.7           # Blend across teachers
+clip_teacher_weight: 0.3
 
 # Curriculum Learning Strategy
-use_curriculum: true  # Enable curriculum learning
-start_region_training_epoch: 20  # Start region-based training after N epochs
-region_training_interval: 5  # Update region training every N epochs
-curriculum_difficulty_schedule: linear  # Options: linear, exponential, step
+use_curriculum: true                    # Train easy→hard to stabilize early epochs
+start_region_training_epoch: 20         # When to begin region emphasis
+region_training_interval: 5             # Update cadence for region schedule
+curriculum_difficulty_schedule: linear  # linear|exponential|step
 
 # Hardware Configuration
-device: cuda  # Options: cuda, cpu, mps
-distributed: false  # Enable for multi-GPU training
-local_rank: -1  # Local rank for distributed training
-world_size: 1  # Number of GPUs for distributed training
-ddp_backend: nccl  # Backend for distributed training
+device: cuda                 # Primary device: cuda|cpu|mps
+distributed: false           # Set true for multi‑GPU runs (DDP)
+local_rank: -1               # Populated by launcher; leave -1 for single‑GPU
+world_size: 1                # Number of GPUs to use
+ddp_backend: nccl            # DDP backend (use nccl on Linux/CUDA)
 
 # Experiment Tracking
-use_tensorboard: true
-use_wandb: false  # Set to true if using Weights & Biases
+use_tensorboard: true        # Local summaries written under ./runs
+use_wandb: false             # Remote experiment tracking
 wandb_project: anime-tagger
-wandb_run_name: null  # Will be auto-generated if null
-wandb_entity: null  # Your W&B entity/username
+wandb_run_name: null         # Auto‑named if null
+wandb_entity: null           # Your W&B username/team
 
 # Training Stability
-seed: 42  # Random seed for reproducibility
-deterministic: false  # True for exact reproducibility (slower)
-benchmark: true  # Enable cudnn benchmarking for performance
+seed: 42                      # Set for reproducibility across runs
+deterministic: false          # True disables certain autotuning for repeatability
+benchmark: true               # True enables cuDNN autotune (set false if deterministic)
 
 # Early Stopping
-early_stopping_patience: 10  # Stop if no improvement for N epochs
-early_stopping_threshold: 0.0001  # Minimum change to qualify as improvement
+early_stopping_patience: 10        # No improvement for N epochs → stop
+early_stopping_threshold: 0.0001   # Minimal delta that counts as improvement
 
 # Additional Settings for Production Training
 # These can be uncommented and adjusted as needed

--- a/configs/vocabulary.yaml
+++ b/configs/vocabulary.yaml
@@ -1,6 +1,7 @@
 vocabulary:
-  ignore_tags_file: "./configs/Tags_ignore.txt"
-  min_frequency: 1
+  ignore_tags_file: "./configs/Tags_ignore.txt"  # Tags to always drop during vocab build
+  min_frequency: 1                               # Keep tokens appearing ≥ this many times
   special_tokens:
     pad: "<PAD>"
     unk: "<UNK>"
+  # Note: Special tokens are reserved; avoid collisions with real tags.


### PR DESCRIPTION
## Summary
- add comprehensive README for configs folder and orientation-map docs
- document training/inference/runtime configs with quick-start guidance and safety notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac582379148321a79ef6880845df77