### PR TITLE
Align config paths and schema

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -36,5 +36,9 @@ See `orientation_map.README.md` in this folder for how flips and symmetric/asymm
 
 ### Changelog
 
-- Added human‑readable comments across configs
+-
+- Added human-readable comments across configs
 - Added this README and `orientation_map.README.md`
+- Migrated `inference_config.yaml` to nested schema (preprocessing/runtime/postprocessing/io/input).
+- Fixed `vocabulary.ignore_tags_file` to point at `./Tags_ignore.txt` (repo root).
+- Made `export_config.yaml` reference `./artifacts/thresholds.json` to match the calibration tool output.

--- a/configs/export_config.yaml
+++ b/configs/export_config.yaml
@@ -7,5 +7,5 @@ export:
     model: "model.onnx"
     quantized: "model.int8.onnx"
   metadata_paths:
-    thresholds: "./configs/thresholds.json"
+    thresholds: "./artifacts/thresholds.json"    # Matches tools/calibrate_thresholds.py default output
  # Tip: After export, use onnxruntime to sanity‑check a forward pass.

--- a/configs/inference_config.yaml
+++ b/configs/inference_config.yaml
@@ -1,96 +1,31 @@
-# Inference Configuration for Anime Image Tagger
-# This configuration controls model inference behavior and output formatting
+# Inference Configuration (migrated to nested schema)
+# Keep training/inference normalization identical; use the nested keys this repo reads in code.
 
-# QUICK NOTES
-# • Keep image_size/normalize_mean/normalize_std identical to training.
-# • If you hit VRAM limits, lower batch_size or set use_fp16:true (CUDA only).
-# • Enable compile_model for speedups on PyTorch 2.x; not all platforms benefit.
-# • API section only matters if running the server mode.
+# Model Settings that remain top-level (referenced in various scripts)
+model_path: "./checkpoints/best_model.pt"
 
-# Model Settings
-model_path: "./checkpoints/best_model.pt"  # Path to trained model checkpoint
-vocab_dir: "./vocabulary"  # Directory containing vocabulary files
-device: "cuda"  # Device to use: cuda, cpu, or mps (for Apple Silicon)
-use_fp16: true  # Use half precision for faster inference (requires CUDA)
-compile_model: false  # Whether to compile model with torch.compile (experimental)
-
-# Image Preprocessing
-image_size: 640  # Input image size (must match training)
-# CRITICAL: These values MUST match training normalization (HDF5_loader.py defaults)
-# Using anime-optimized values instead of ImageNet for consistency
-normalize_mean: [0.5, 0.5, 0.5]  # Anime artwork normalization mean (matches training)
-normalize_std: [0.5, 0.5, 0.5]  # Anime artwork normalization std (matches training)
-pad_color: [114, 114, 114]  # Gray padding color for letterboxing
- # Note: pad_color must match training/preprocessing to avoid artifacts.
-
-# Prediction Settings
-prediction_threshold: 0.5  # Tags above this probability are returned
-adaptive_threshold: true  # Dynamically adjust threshold based on predictions
-min_predictions: 5  # Minimum number of tags to predict per image
-max_predictions: 50  # Maximum number of tags to predict per image
-top_k: null  # If set, only return top-k predictions (null = no limit)
-
-# Tag Filtering
-filter_nsfw: false  # Whether to filter NSFW tags from output
-nsfw_tags:  # List of NSFW tags to filter
-  - explicit
-  - questionable
-  - sensitive
-  - nude
-  - sexual_content
-
-blacklist_tags: []  # Tags to always exclude from predictions
-whitelist_tags: null  # If set, only these tags can be predicted (null = all tags allowed)
-
-# Post-processing
-apply_implications: true  # Apply tag implications (e.g., cat_ears -> animal_ears)
-resolve_aliases: true  # Resolve tag aliases to canonical forms
-group_by_category: false  # Group output tags by category (character, artist, etc.)
-remove_underscores: true  # Replace underscores with spaces in tag names
- # Tip: For UI outputs, set group_by_category:true and include_scores:true for clarity.
-
-# Performance Settings
-batch_size: 32  # Batch size for processing multiple images
-num_workers: 4  # Number of data loading workers
-use_tensorrt: false  # Use TensorRT optimization (requires TensorRT installation)
-optimize_for_speed: false  # Apply model optimizations (may affect accuracy slightly)
-batch_timeout_ms: 100  # Timeout for batch accumulation in streaming mode
-max_batch_size: 32  # Maximum batch size for dynamic batching
-
-# Output Format
-output_format: "json"  # Output format: json, text, csv, xml, or yaml
-include_scores: true  # Include confidence scores with predictions
-score_decimal_places: 3  # Number of decimal places for scores
-sort_by_score: true  # Sort tags by confidence score (highest first)
-
-# API Settings (if running as service)
-enable_api: false  # Enable REST API server
-api_host: "0.0.0.0"  # API server host
-api_port: 8000  # API server port
-api_workers: 4  # Number of API worker processes
-api_max_image_size: 10485760  # Maximum image size in bytes (10MB)
-api_rate_limit: 100  # Rate limit: requests per minute
-api_cors_origins:  # CORS allowed origins
-  - "*"  # Allow all origins (configure properly for production)
- # In production, replace "*" with a specific list of allowed origins.
 preprocessing:
   image_size: 640
   normalize_mean: [0.5, 0.5, 0.5]
   normalize_std: [0.5, 0.5, 0.5]
+
 runtime:
   device: "cuda"
   use_fp16: true
   tta_flip: false
+
 postprocessing:
   threshold: 0.5
   top_k: 10
-  thresholds_path: null
-  eye_color_exclusive: false
+  thresholds_path: null   # If you calibrate, point at ./artifacts/thresholds.json
+
 io:
   output_format: "json"
   save_visualizations: false
   visualization_dir: "./visualizations"
+
 input:
   image_extensions: [".jpg", ".jpeg", ".png", ".webp"]
+
 onnx_runtime:
   providers: ["CUDAExecutionProvider", "CPUExecutionProvider"]

--- a/configs/vocabulary.yaml
+++ b/configs/vocabulary.yaml
@@ -1,5 +1,5 @@
 vocabulary:
-  ignore_tags_file: "./configs/Tags_ignore.txt"  # Tags to always drop during vocab build
+  ignore_tags_file: "./Tags_ignore.txt"          # Lives at repo root; keep path stable for loaders
   min_frequency: 1                               # Keep tokens appearing ≥ this many times
   special_tokens:
     pad: "<PAD>"


### PR DESCRIPTION
## Summary
- point vocabulary ignore_tags_file at repo-root Tags_ignore.txt
- reference calibrated thresholds under artifacts
- migrate inference_config.yaml to nested preprocessing/runtime/postprocessing/io/input schema
- document config changes in README changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac70ee97a8832187a013f387c928d9