### PR TITLE
Configure memory usage to limit RAM footprint.

### DIFF
--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -367,6 +367,7 @@ class DataConfig(BaseConfig):
     
     # Caching
     cache_size_gb: float = 105.0
+    l1_per_worker_mb: int = 256
     preload_files: int = 2
     use_memory_cache: bool = True
     

--- a/configs/unified_config.yaml
+++ b/configs/unified_config.yaml
@@ -8,7 +8,8 @@ experiment_name: "default_experiment"
 output_root: "./experiments"
 log_level: "INFO"
 log_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-max_memory_gb: null
+# Set a target for total system RAM usage. This is a guideline and not strictly enforced.
+max_memory_gb: 220.0
 max_gpu_memory_gb: null
 
 # --------------------------------------------------------------------
@@ -87,7 +88,7 @@ data:
   drop_last: false
   
   # Caching
-  cache_size_gb: 105.0
+  cache_size_gb: 80.0
   preload_files: 2
   use_memory_cache: true
   


### PR DESCRIPTION
This commit introduces several changes to reduce and control the application's memory usage, with a target of keeping total system RAM usage under 220GB.

The key changes are:

1.  **Reduce L2 Data Cache Size:** The `data.cache_size_gb` in `configs/unified_config.yaml` has been reduced from 105.0 GB to 80.0 GB. This is the most significant change and will substantially lower the pressure on the system's file cache and overall RAM usage.

2.  **Add Missing L1 Cache Configuration:** The `l1_per_worker_mb` parameter, which controls the per-worker L1 cache size, was missing from the `DataConfig` definition. It has been added to `Configuration_System.py` with a default value of 256 MB. This fixes a latent bug and makes the L1 cache size explicit and configurable.

3.  **Set Global Memory Limit Guideline:** The `max_memory_gb` parameter in `configs/unified_config.yaml` has been set to 220.0. A comment has been added to clarify that this is a target guideline and is not currently enforced programmatically.