### PR TITLE
Refactor: Improve data path handling and error messaging

### DIFF
--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -339,12 +339,7 @@ class StorageLocation:
 class DataConfig(BaseConfig):
     """Data loading and preprocessing configuration"""
     # Storage locations
-    storage_locations: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"path": "/home/user/datasets/anime_curated", "priority": 0, "type": "local", "enabled": True},
-        {"path": "/mnt/das/anime_archive", "priority": 1, "type": "das", "enabled": True},
-        {"path": "/mnt/nas/anime_dataset/primary", "priority": 2, "type": "nas", "enabled": True},
-        {"path": "/mnt/nas/anime_dataset/video_frames", "priority": 3, "type": "nas", "enabled": True}
-    ])
+    storage_locations: List[Dict[str, Any]] = field(default_factory=list)
     
     # Paths
     hdf5_dir: str = "/home/user/datasets/teacher_features"

--- a/train_direct.py
+++ b/train_direct.py
@@ -219,7 +219,13 @@ def train_with_orientation_tracking(config: FullConfig):
     active_location = next((loc for loc in config.data.storage_locations if loc.get('enabled')), None)
 
     if not active_location:
-        raise ValueError("No enabled storage location found in data.storage_locations. Please check your configuration.")
+        error_msg = (
+            "No enabled storage location found in your configuration.\n"
+            "Please ensure you are providing a configuration file using the --config argument, for example:\n"
+            "  python train_direct.py --config configs/unified_config.yaml\n"
+            "And that your configuration file has an enabled entry under data.storage_locations."
+        )
+        raise ValueError(error_msg)
 
     active_data_path = Path(active_location['path'])
     logger.info(f"Using active data path: {active_data_path}")


### PR DESCRIPTION
This commit addresses an issue where the training script would fail with an unhelpful error if no configuration file was provided. The script was falling back to a hardcoded default data path that did not exist in the user's environment.

Changes:
- Removed the hardcoded default `storage_locations` from `Configuration_System.py` to prevent the script from using an incorrect path.
- Centralized the `active_data_path` resolution logic in `train_direct.py`.
- Added a clear, instructive error message in `train_direct.py` that guides the user to provide a configuration file using the `--config` flag if no data path is found.
- The `create_dataloaders` function in `HDF5_loader.py` now receives the active data path as an argument, removing redundant logic.