### PR TITLE
Fix Adan optimizer beta handling and monitor initialization

### DIFF
--- a/configs/unified_config.yaml
+++ b/configs/unified_config.yaml
@@ -138,6 +138,7 @@ training:
   optimizer: "adan"
   adam_beta1: 0.9
   adam_beta2: 0.999
+  adan_beta3: 0.99
   adam_epsilon: 1.0e-8
   
   # Scheduler


### PR DESCRIPTION
## Summary
- Initialize training monitor before attempting to log model graph
- Handle Adan optimizer's beta parameters with a safe fallback and add beta3 to config

## Testing
- `python -m py_compile train_direct.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad32ccabcc8321abfea2073f9393e1