### PR TITLE
Decouple debug augmentation flags from data config

### DIFF
--- a/train_direct.py
+++ b/train_direct.py
@@ -279,6 +279,7 @@ def train_with_orientation_tracking(config: FullConfig):
         rank=config.training.local_rank,
         world_size=config.training.world_size,
         seed=seed,
+        debug_config=config.debug,
     )
 
     # Pre-training validation


### PR DESCRIPTION
## Summary
- allow SimplifiedDataset to accept a DebugConfig and store it separately from DataConfig
- use DebugConfig when saving augmentation visualizations
- plumb debug config through `create_dataloaders` and `train_direct`

## Testing
- `python -m py_compile HDF5_loader.py train_direct.py`
- `python - <<'PY'
from pathlib import Path
from PIL import Image
import json, shutil
from Configuration_System import DataConfig, DebugConfig
from vocabulary import TagVocabulary
from HDF5_loader import SimplifiedDataset

root = Path('tmp_ds')
if root.exists():
    shutil.rmtree(root)
root.mkdir()
img_path = root / 'img1.png'
Image.new('RGB', (10,10), color=(255,0,0)).save(img_path)
ann = {"filename":"img1.png", "tags":"red", "rating":"general"}
ann_path = root / 'ann1.json'
with open(ann_path,'w') as f: json.dump(ann, f)

vocab = TagVocabulary()
vocab.build_from_annotations([ann_path], top_k=None)

config = DataConfig()
config.augmentation_enabled = False
config.random_flip_prob = 0.0

dbg = DebugConfig(enabled=True, visualize_augmentations=True, augmentation_visualization_path=str(root/'aug_vis'))

ds = SimplifiedDataset(config, [ann_path], split='train', vocab=vocab, debug_config=dbg)
item = ds[0]
print('keys', item.keys())
print('aug_vis_files', sorted((root/'aug_vis').glob('**/*')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ae341954b0832199596264a81a5a0d