### PR TITLE
Improve TensorBoard prediction sample readability

### DIFF
--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -889,6 +889,15 @@ class ValidationConfig(BaseConfig):
 
 
 @dataclass
+class TBImageLoggingConfig(BaseConfig):
+    """Configuration for TensorBoard image and text sample logging."""
+    max_samples: int = 4
+    topk: int = 15
+    log_native_resolution: bool = True
+    dpi_for_figures: int = 220
+
+
+@dataclass
 class MonitorConfig(BaseConfig):
     """Configuration for monitoring system"""
     # Logging
@@ -948,6 +957,9 @@ class MonitorConfig(BaseConfig):
     # Remote monitoring
     enable_prometheus: bool = False
     prometheus_port: int = 8080
+
+    # TensorBoard image logging helpers
+    tb_image_logging: TBImageLoggingConfig = field(default_factory=TBImageLoggingConfig)
 
     # History
     max_history_size: int = 10000

--- a/configs/unified_config.yaml
+++ b/configs/unified_config.yaml
@@ -353,6 +353,12 @@ monitor:
   alert_webhook_url: "https://discord.com/api/webhooks/1349139188804485201/1YQ3LmlLVndj7dHSEIPc13fep_EYI3hqEyKtMUuUOnP8YGWMnPDMAR7x-wgkgkvzw35I"
   # --------------------------------------------------------------------
 
+  tb_image_logging:
+    max_samples: 4          # how many examples to log per val step
+    topk: 15                # how many tags per sample in Text tab
+    log_native_resolution: true  # keep images crisp in TB
+    dpi_for_figures: 220          # only used if you later add composite figures
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Debug
 # Options for debugging training runs.

--- a/train_direct.py
+++ b/train_direct.py
@@ -547,13 +547,15 @@ def train_with_orientation_tracking(config: FullConfig):
                 if val_step == 0 and config.training.use_tensorboard:
                     tag_preds = torch.sigmoid(outputs['tag_logits'])
                     tag_names = [vocab.index_to_tag[i] for i in range(len(vocab.index_to_tag))]
-                    monitor.log_images(
+                    monitor.log_predictions(
                         step=global_step,
                         images=images,
                         predictions=tag_preds,
                         targets=tag_labels,
                         tag_names=tag_names,
-                        prefix="val"
+                        prefix="val",
+                        max_images=config.monitor.tb_image_logging.max_samples,
+                        topk=config.monitor.tb_image_logging.topk,
                     )
         
         avg_val_loss = val_loss / len(val_loader)


### PR DESCRIPTION
## Summary
- add TBImageLoggingConfig and tb_image_logging options to config
- log prediction samples as separate images and markdown tables for top-k tags
- switch validation logging to new API with configurable sample count and top-k

## Testing
- `python Configuration_System.py validate configs/unified_config.yaml`
- `python train_direct.py --help`
- `python Monitor_log.py --help`
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68af176dd17c832194d53b9b1d59e00b