### PR TITLE
Upgrade PyTorch dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,11 @@ scikit-learn==1.0.0
 scipy==1.7.0
 seaborn==0.11.0
 tensorboard>=2.14,<2.17
-torch==1.10.0
-torchvision==0.11.0
+# Upgrade PyTorch stack for modern APIs and CUDA 12 support
+torch>=2.3
+torchvision>=0.18
+# Ensure matching CUDA runtime when installing via pip
+pytorch-cuda>=12.1; platform_system=='Linux' and platform_machine=='x86_64'
 tqdm==4.62.0
 uvicorn==0.15.0  # for API
 wandb==0.12.0  # optional


### PR DESCRIPTION
## Summary
- upgrade torch and torchvision requirements for modern APIs
- add pytorch-cuda package for CUDA 12 runtime compatibility

## Testing
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`
- `python - <<'PY'
import torch
print('torch version:', torch.__version__)
print('cuda available:', torch.cuda.is_available())
PY` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68af3dbc7ea08321ac53b439d735bca7