### PR TITLE
refactor: centralize sensitive config

### DIFF
--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -20,6 +20,12 @@ from collections import defaultdict
 import re
 import warnings
 
+# Import sensitive defaults
+try:
+    from sensitive_config import ALERT_WEBHOOK_URL
+except ImportError:  # pragma: no cover - fallback when file missing
+    ALERT_WEBHOOK_URL = None
+
 logger = logging.getLogger(__name__)
 
 # Type variable for generic config classes
@@ -934,7 +940,8 @@ class MonitorConfig(BaseConfig):
     alert_on_training_stuck_minutes: int = 30
     alert_on_loss_explosion: float = 10.0
     alert_on_nan_loss: bool = True
-    alert_webhook_url: Optional[str] = None  # For Slack/Discord alerts
+    # Webhook URL is loaded from sensitive_config to avoid hardcoding secrets
+    alert_webhook_url: Optional[str] = ALERT_WEBHOOK_URL
 
     # Performance profiling
     enable_profiling: bool = False

--- a/configs/unified_config.yaml
+++ b/configs/unified_config.yaml
@@ -347,9 +347,9 @@ monitor:
   alert_on_nan_loss: true
   # --------------------------------------------------------------------
   # --- WEBHOOK REVIEW POINT ---
-  # This is the new field for the Discord webhook URL.
-  # Replace "your_webhook_url_here" with your actual Discord webhook URL.
-  alert_webhook_url: "https://discord.com/api/webhooks/1349139188804485201/1YQ3LmlLVndj7dHSEIPc13fep_EYI3hqEyKtMUuUOnP8YGWMnPDMAR7x-wgkgkvzw35I"
+  # The actual webhook URL is stored separately in sensitive_config.py.
+  # Replace ALERT_WEBHOOK_URL in that file with your private Discord webhook.
+  # alert_webhook_url: "your_webhook_url_here"
   # --------------------------------------------------------------------
 
   tb_image_logging:

--- a/sensitive_config.py
+++ b/sensitive_config.py
@@ -1,0 +1,8 @@
+"""Centralized placeholder for sensitive configuration values.
+
+Replace the placeholder values with your actual secrets in your local copy.
+This file is tracked with placeholders only to avoid exposing real credentials.
+"""
+
+# Discord or Slack webhook URL for alerts
+ALERT_WEBHOOK_URL = "your_webhook_url_here"


### PR DESCRIPTION
## Summary
- add `sensitive_config.py` to store webhook URL and other secrets
- default to `sensitive_config` in configuration and monitoring
- remove public webhook from `unified_config.yaml`

## Testing
- `git ls-files '*.py' | xargs -I {} python3 -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68af5a1887dc83219468952dd2613084