### PR TITLE
Refine validation pipeline and misc fixes

### DIFF
--- a/Monitor_log.py
+++ b/Monitor_log.py
@@ -40,9 +40,14 @@ from tqdm import tqdm
 
 # Load sensitive configuration values
 try:
-    from sensitive_config import ALERT_WEBHOOK_URL
+    from sensitive_config import ALERT_WEBHOOK_URL as _DEFAULT_WEBHOOK
 except ImportError:  # pragma: no cover - fallback when file missing
-    ALERT_WEBHOOK_URL = None
+    _DEFAULT_WEBHOOK = None
+import os
+
+
+def _resolve_webhook_url(cfg_value: Optional[str]) -> Optional[str]:
+    return cfg_value or os.getenv("OPPAI_ALERT_WEBHOOK") or _DEFAULT_WEBHOOK
 
 # Optional imports with proper handling
 try:
@@ -130,7 +135,7 @@ class AlertSystem:
         log_method(f"ALERT: {title} - {message}")
         
         # Send to webhook if configured
-        webhook_url = self.config.alert_webhook_url or ALERT_WEBHOOK_URL
+        webhook_url = _resolve_webhook_url(self.config.alert_webhook_url)
         if webhook_url:
             self._send_webhook_alert(alert, webhook_url)
         

--- a/model_architecture.py
+++ b/model_architecture.py
@@ -107,14 +107,13 @@ class TransformerBlock(nn.Module):
             k = k.transpose(1, 2)
             v = v.transpose(1, 2)
             
-            # Build attention mask with SDPA semantics (True = keep)
+            # Build attention mask with SDPA semantics (True = masked)
             attn_mask = None
             if key_padding_mask is not None:
                 # If any sample masks all positions, fail fast
                 if torch.all(key_padding_mask, dim=1).any():
                     raise RuntimeError("key_padding_mask masks all keys for at least one sample.")
-                # Invert mask for SDPA: original True means ignore
-                attn_mask = (~key_padding_mask).unsqueeze(1).unsqueeze(2)  # (B,1,1,L)
+                attn_mask = key_padding_mask.unsqueeze(1).unsqueeze(2)  # (B,1,1,L)
 
             # Use scaled_dot_product_attention with flash backend when available
             attn_out = F.scaled_dot_product_attention(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ imagehash==4.2.0  # optional
 lmdb==1.3.0
 matplotlib==3.4.0
 networkx==2.6.0  # optional
-numpy==1.21.0
+numpy>=1.23,<3
 onnx==1.11.0
 onnxruntime==1.10.0
 onnxsim==0.4.36
-opencv-python==4.5.0
-pandas==1.3.0
+opencv-python>=4.8
+pandas>=1.5
 pillow==9.0.0
 prometheus-client==0.12.0  # optional
 psutil==5.8.0
@@ -20,7 +20,7 @@ requests>=2.28
 protobuf>=3.20.3,<5
 werkzeug>=2.2,<5
 scikit-learn==1.0.0
-scipy==1.7.0
+scipy>=1.9
 seaborn==0.11.0
 tensorboard>=2.14,<2.17
 # Upgrade PyTorch stack for modern APIs and CUDA 12 support

--- a/train_direct.py
+++ b/train_direct.py
@@ -411,7 +411,10 @@ def train_with_orientation_tracking(config: FullConfig):
 
     # GradScaler is only needed for float16 AMP.
     use_scaler = amp_enabled and amp_dtype == torch.float16
-    scaler = GradScaler(device='cuda', enabled=use_scaler)
+    try:
+        scaler = GradScaler("cuda", enabled=use_scaler)
+    except TypeError:
+        scaler = GradScaler(enabled=use_scaler)
     if amp_enabled:
         logger.info(f"AMP enabled with dtype={amp_dtype} and GradScaler={'enabled' if use_scaler else 'disabled'}.")
     else:


### PR DESCRIPTION
## Summary
- fix attention mask semantics for flash attention
- handle GradScaler API differences
- resolve alert webhook from config, env, or default
- rework validation loop to use configuration-based dataloaders
- modernize core dependency versions

## Testing
- `python train_direct.py --help`
- `python validation_loop.py --help`
- `python Monitor_log.py --help` *(fails: Invalid URL 'your_webhook_url_here')*
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68af637e57bc83219131d8cebde1ddbe