### PR TITLE
Fix fallback image lookup and configurable vocabulary path

### DIFF
--- a/HDF5_loader.py
+++ b/HDF5_loader.py
@@ -1767,7 +1767,12 @@ class SimplifiedDataset(Dataset):
                 if not os.path.isdir(directory):
                     raise # Directory itself doesn't exist, re-raise original error.
 
-                found_files = [f for f in os.listdir(directory) if f.endswith(filename)]
+                filename_stem = Path(filename).stem
+                found_files = [
+                    f
+                    for f in os.listdir(directory)
+                    if Path(f).stem == filename_stem
+                ]
 
                 if len(found_files) == 1:
                     new_path = os.path.join(directory, found_files[0])

--- a/Inference_Engine.py
+++ b/Inference_Engine.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 from collections import defaultdict, deque
 import threading
 import queue
+import argparse
 
 import gzip
 import base64
@@ -969,19 +970,36 @@ class InferenceEngine:
 
 # Example usage
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run inference using a trained model")
+    parser.add_argument(
+        "--model",
+        default="./checkpoints/best_model.pt",
+        help="Path to model checkpoint (.pt)",
+    )
+    parser.add_argument(
+        "--config",
+        default="./checkpoints/model_config.json",
+        help="Path to model config JSON",
+    )
+    parser.add_argument(
+        "--vocab",
+        default=str(DEFAULT_VOCAB_PATH),
+        help="Path to vocabulary JSON file",
+    )
+    args = parser.parse_args()
+
     # Configure inference
     # Note: image_size should match the training configuration (640 for ViT, not 448)
     config = InferenceConfig(
-        model_path="./checkpoints/best_model.pt",  # Standardize to .pt
-        # Explicitly set the vocabulary path
-        vocab_path="/media/andrewk/qnap-public/workspace/OppaiOracle/vocabulary.json",
-        config_path="./checkpoints/model_config.json",
+        model_path=args.model,
+        vocab_path=args.vocab,
+        config_path=args.config,
         batch_size=32,
         threshold=0.5,
         top_k=10,
         enable_monitoring=True,
         enable_cache=True,
-        image_size=640  # Match training image size for ViT
+        image_size=640,  # Match training image size for ViT
     )
 
     # Example of what should be saved during training (add to training script):

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ You can run inference using either the PyTorch model or the ONNX model.
 
 -   **PyTorch Inference:**
     ```bash
-    python Inference_Engine.py --config configs/unified_config.yaml --image /path/to/your/image.jpg
+    python Inference_Engine.py --config configs/unified_config.yaml --vocab vocabulary.json --image /path/to/your/image.jpg
     ```
+    The `--vocab` argument defaults to `vocabulary.json` in the project root if not specified.
 
 -   **ONNX Inference:**
     ```bash


### PR DESCRIPTION
## Summary
- Prevent fallback image search from matching wrong files by comparing filename stems
- Allow inference vocabulary path to be supplied via CLI with project-root default
- Document vocabulary CLI flag in README

## Testing
- `python HDF5_loader.py`
- `python Inference_Engine.py --help`
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68af79a174f8832199f6290cdbc0f8f8