### PR TITLE
Fix dataset cleanup and training utilities

### DIFF
--- a/HDF5_loader.py
+++ b/HDF5_loader.py
@@ -1324,11 +1324,6 @@ class SimplifiedDataset(Dataset):
             # Track permanently failed images
             self._failed_images: set[str] = set()
 
-            # Initialize known-good sample pool for fallback
-            self._known_good_indices: List[int] = []
-            self._known_good_lock = threading.Lock()
-            self._populate_known_good_pool()
-
             # Max retry attempts - scale with dataset size
             self._max_retry_attempts = min(16, max(8, len(self.annotations) // 1000))
             logger.info(f"Max retry attempts set to {self._max_retry_attempts} for {len(self.annotations)} samples")
@@ -1391,30 +1386,6 @@ class SimplifiedDataset(Dataset):
 
             # Monitor memory at initialization
             self._log_memory_status("Dataset initialization")
-
-    def _populate_known_good_pool(self, sample_size: int = 100):
-        """Populate a pool of known-good sample indices for fallback"""
-        if len(self.annotations) == 0:
-            return
-
-        sample_size = min(sample_size, len(self.annotations))
-        test_indices = np.random.choice(len(self.annotations), size=sample_size, replace=False)
-
-        good_indices = []
-        for idx in test_indices:
-            image_path = self.annotations[idx]['image_path']
-            try:
-                # Quick validation - just try to open
-                with Image.open(image_path) as img:
-                    _ = img.size
-                good_indices.append(idx)
-            except Exception:
-                continue
-
-        with self._known_good_lock:
-            self._known_good_indices = good_indices
-
-        logger.info(f"Known-good pool populated with {len(good_indices)}/{sample_size} valid samples")
 
     def _load_annotations(self, json_files: List[Path]) -> None:
         """Parse annotation files and populate ``self.annotations``.
@@ -1969,16 +1940,8 @@ class SimplifiedDataset(Dataset):
 
             # Avoid infinite loops by checking visited indices
             if idx in visited_indices:
-                # Try to get a known-good sample
-                with self._known_good_lock:
-                    if self._known_good_indices:
-                        idx = random.choice(self._known_good_indices)
-                        if idx in visited_indices:
-                            # Even our good samples have been tried, give up
-                            break
-                    else:
-                        # No good samples available, increment and continue
-                        idx = (idx + 1) % len(self.annotations)
+                logger.warning(f"Repeated index {idx} encountered during loading")
+                break
 
             visited_indices.add(idx)
 
@@ -2205,19 +2168,10 @@ class SimplifiedDataset(Dataset):
                 tag_labels = self.vocab.encode_tags(tags)
                 rating_label = self.vocab.rating_to_index.get(anno['rating'], self.vocab.rating_to_index['unknown'])
 
-                # Success! Reset error count and add to known-good pool
+                # Success! Reset error count
                 with self._error_counts_lock:
                     if image_path in self._error_counts:
                         del self._error_counts[image_path]
-
-                # Add successful index to known-good pool (with probability to avoid bias)
-                if random.random() < 0.1:  # 10% chance
-                    with self._known_good_lock:
-                        if actual_idx not in self._known_good_indices:
-                            self._known_good_indices.append(actual_idx)
-                            # Keep pool size bounded
-                            if len(self._known_good_indices) > 200:
-                                self._known_good_indices.pop(0)
 
                 # Save metadata for augmentation visualization
                 if vis_dir:
@@ -2357,8 +2311,17 @@ class SimplifiedDataset(Dataset):
 
     def __del__(self):
         """Cleanup when dataset is destroyed."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    def close(self):
+        """Release any external resources held by the dataset."""
         if hasattr(self, 'background_validator'):
             self.background_validator.stop()
+        if getattr(self, 'validation_index', None) is not None:
+            self.validation_index.close()
 
 def validate_dataset(dataloader: DataLoader, vocab: TagVocabulary, config: Any, num_batches_to_check: int):
     """

--- a/loss_functions.py
+++ b/loss_functions.py
@@ -90,11 +90,10 @@ class AsymmetricFocalLoss(nn.Module):
         pos_weights = targets * torch.pow(1 - probs, self.gamma_pos)
         neg_weights = (1 - targets) * torch.pow(probs, self.gamma_neg)
 
-        # Apply focal weights with unified alpha
-        # Note: The original implementation had a slight conceptual error in how it applied
-        # weights to the combined BCE loss. We are preserving the original formula's
-        # structure but applying it to the more stable BCE loss calculation.
-        focal_loss = self.alpha * (pos_weights * bce_loss + neg_weights * bce_loss)
+        # Apply focal weights with separate positive/negative weighting
+        pos_loss = pos_weights * bce_loss
+        neg_loss = neg_weights * bce_loss
+        focal_loss = self.alpha * pos_loss + (1 - self.alpha) * neg_loss
 
         # Apply sample weights if provided (for frequency-based sampling)
         if sample_weights is not None:

--- a/train_direct.py
+++ b/train_direct.py
@@ -411,10 +411,7 @@ def train_with_orientation_tracking(config: FullConfig):
 
     # GradScaler is only needed for float16 AMP.
     use_scaler = amp_enabled and amp_dtype == torch.float16
-    try:
-        scaler = GradScaler("cuda", enabled=use_scaler)
-    except TypeError:
-        scaler = GradScaler(enabled=use_scaler)
+    scaler = GradScaler(device_type="cuda", enabled=use_scaler)
     if amp_enabled:
         logger.info(f"AMP enabled with dtype={amp_dtype} and GradScaler={'enabled' if use_scaler else 'disabled'}.")
     else:


### PR DESCRIPTION
## Summary
- prevent dataloader from silently swapping failed samples and ensure SQLite validation index is closed
- fix GradScaler initialization for AMP training
- refactor inference configuration to reuse central dataclass and avoid global mutations
- flatten hyperparameter logging before sending to TensorBoard
- correct asymmetric focal loss by weighting positive/negative terms separately

## Testing
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`
- `python train_direct.py --help` *(fails: No module named 'torch')*
- `python Inference_Engine.py --help` *(fails: No module named 'yaml')*
- `python Monitor_log.py --help` *(fails: No module named 'psutil')*
- `python HDF5_loader.py --help` *(fails: No module named 'lmdb')*
- `python loss_functions.py --help` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68af7c323bfc8321ac7741d650162642