### PR TITLE
Refactor dataset loader and fix critical training and inference bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ OppaiOracle, also known as **MAID (Model for AI-based Detection)**, is a PyTorch
 - `model_architecture.py`: Defines the neural network.
 - `adan_optimizer.py` and `custom_drop_path.py`: Optional optimization and regularization components.
 - `orientation_handler.py`: Handles image orientation metadata.
-- `HDF5_loader.py`: Utilities for loading datasets stored in HDF5 format.
+- `dataset_loader.py`: Utilities for loading datasets stored in HDF5 format.
 - `Dataset_Analysis.py`: Tools for inspecting datasets.
 - `Inference_Engine.py`: PyTorch inference logic.
 - `ONNX_Export.py`: Exports trained models to ONNX format.

--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -410,7 +410,7 @@ class DataConfig(BaseConfig):
     skip_unmapped: bool = True
     orientation_safety_mode: str = "conservative"
 
-    # L2 Caching (from HDF5_loader.py usage)
+    # L2 Caching (from dataset_loader.py usage)
     l2_cache_enabled: bool = field(default=False, metadata={"help": "Enable L2 (LMDB) caching"})
     l2_cache_path: str = field(default="./l2_cache", metadata={"help": "Path to L2 cache directory"})
     l2_max_size_gb: float = field(default=48.0, metadata={"help": "Maximum size of L2 cache in GB"})
@@ -418,17 +418,17 @@ class DataConfig(BaseConfig):
     cache_precision: str = field(default='uint8', metadata={"help": "Precision for cached images ('uint8', 'float16', 'bfloat16', 'float32')"})
     canonical_cache_dtype: str = field(default='uint8', metadata={"help": "Canonical dtype for cache storage"})
 
-    # Dataset behavior (from HDF5_loader.py usage)
+    # Dataset behavior (from dataset_loader.py usage)
     patch_size: int = field(default=16, metadata={"help": "Patch size for vision transformer"})
     validate_on_init: bool = field(default=False, metadata={"help": "Validate all images on dataset init"})
     skip_error_samples: bool = field(default=True, metadata={"help": "Skip samples that cause loading errors"})
     collect_augmentation_stats: bool = field(default=False, metadata={"help": "Collect detailed augmentation stats"})
 
-    # Weighted Sampling (from HDF5_loader.py usage)
+    # Weighted Sampling (from dataset_loader.py usage)
     frequency_weighted_sampling: bool = field(default=False, metadata={"help": "Enable frequency-weighted sampling"})
     sample_weight_power: float = field(default=0.5, metadata={"help": "Power for inverse frequency weighting"})
 
-    # Working Set Sampler (from HDF5_loader.py usage)
+    # Working Set Sampler (from dataset_loader.py usage)
     use_working_set_sampler: bool = field(default=False, metadata={"help": "Enable working set sampler"})
     working_set_pct: float = field(default=5.0, metadata={"help": "Percentage of dataset in the working set"})
     working_set_max_items: int = field(default=400000, metadata={"help": "Max items in the working set"})
@@ -436,7 +436,7 @@ class DataConfig(BaseConfig):
     max_new_uniques_per_epoch: int = field(default=80000, metadata={"help": "Max new unique items per epoch"})
     working_set_refresh_epochs: int = field(default=2, metadata={"help": "Epochs before refreshing working set"})
 
-    # Memory Management (from HDF5_loader.py usage)
+    # Memory Management (from dataset_loader.py usage)
     critical_free_ram_pct: float = field(default=5.0, metadata={"help": "Critical free RAM percentage threshold"})
     low_free_ram_pct: float = field(default=12.0, metadata={"help": "Low free RAM percentage threshold"})
     high_free_ram_pct: float = field(default=25.0, metadata={"help": "High free RAM percentage threshold"})

--- a/Monitor_log.py
+++ b/Monitor_log.py
@@ -1011,8 +1011,17 @@ class TrainingMonitor:
         if getattr(self, "writer", None) is None:
             return
         try:
-            # Ensure values are serializable
-            hp_clean = {k: (v if isinstance(v, (str, int, float, bool)) else str(v)) for k, v in hparams.items()}
+            def _flatten(d, parent=""):
+                items = {}
+                for k, v in d.items():
+                    key = f"{parent}.{k}" if parent else k
+                    if isinstance(v, dict):
+                        items.update(_flatten(v, key))
+                    elif isinstance(v, (str, int, float, bool)):
+                        items[key] = v
+                return items
+
+            hp_clean = _flatten(hparams)
             self.writer.add_hparams(hp_clean, metrics)
         except Exception as e:
             if getattr(self, "logger", None):

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The repository is organized as follows:
 ├── Inference_Engine.py   # Handles model inference
 ├── ONNX_Export.py        # Exports the trained model to ONNX format
 ├── onnx_infer.py         # Runs inference with exported ONNX models
-├── HDF5_loader.py        # Loads data from HDF5 files
+├── dataset_loader.py     # Loads data from HDF5 files
 └── requirements.txt      # Project dependencies
 ```
 

--- a/loss_functions.py
+++ b/loss_functions.py
@@ -90,11 +90,10 @@ class AsymmetricFocalLoss(nn.Module):
         pos_weights = targets * torch.pow(1 - probs, self.gamma_pos)
         neg_weights = (1 - targets) * torch.pow(probs, self.gamma_neg)
 
-        # Apply focal weights with unified alpha
-        # Note: The original implementation had a slight conceptual error in how it applied
-        # weights to the combined BCE loss. We are preserving the original formula's
-        # structure but applying it to the more stable BCE loss calculation.
-        focal_loss = self.alpha * (pos_weights * bce_loss + neg_weights * bce_loss)
+        # Compute separate positive and negative losses
+        pos_loss = pos_weights * bce_loss
+        neg_loss = neg_weights * bce_loss
+        focal_loss = self.alpha * pos_loss + (1 - self.alpha) * neg_loss
 
         # Apply sample weights if provided (for frequency-based sampling)
         if sample_weights is not None:

--- a/train_direct.py
+++ b/train_direct.py
@@ -40,11 +40,11 @@ from orientation_handler import OrientationHandler
 
 # Import base modules with error handling
 try:
-    from HDF5_loader import create_dataloaders
+    from dataset_loader import create_dataloaders
 except ImportError as e:
     error_msg = (
-        f"""MISSING REQUIRED FILE: HDF5_loader.py
-Please ensure HDF5_loader.py exists in the current directory with create_dataloaders function.
+        f"""MISSING REQUIRED FILE: dataset_loader.py
+Please ensure dataset_loader.py exists in the current directory with create_dataloaders function.
 Import error: {e}"""
     )
     raise ImportError(error_msg)
@@ -67,7 +67,7 @@ from training_utils import (
     log_sample_order_hash,
     CosineAnnealingWarmupRestarts,
 )
-from HDF5_loader import AugmentationStats, validate_dataset
+from dataset_loader import AugmentationStats, validate_dataset
 from utils.logging_sanitize import ensure_finite_tensor
 
 # Add after other imports
@@ -411,10 +411,7 @@ def train_with_orientation_tracking(config: FullConfig):
 
     # GradScaler is only needed for float16 AMP.
     use_scaler = amp_enabled and amp_dtype == torch.float16
-    try:
-        scaler = GradScaler("cuda", enabled=use_scaler)
-    except TypeError:
-        scaler = GradScaler(enabled=use_scaler)
+    scaler = GradScaler(enabled=use_scaler)
     if amp_enabled:
         logger.info(f"AMP enabled with dtype={amp_dtype} and GradScaler={'enabled' if use_scaler else 'disabled'}.")
     else:

--- a/utils/logging_setup.py
+++ b/utils/logging_setup.py
@@ -9,7 +9,7 @@ import socket
 import multiprocessing
 from pathlib import Path
 from typing import Optional, Dict, Any
-from HDF5_loader import CompressingRotatingFileHandler
+from dataset_loader import CompressingRotatingFileHandler
 
 # --- Globals for context ---
 _GLOBAL_CONTEXT = {

--- a/validation_loop.py
+++ b/validation_loop.py
@@ -51,7 +51,7 @@ except Exception:  # pragma: no cover
 # Import our modules
 from evaluation_metrics import MetricComputer
 from vocabulary import TagVocabulary, load_vocabulary_for_training, verify_vocabulary_integrity
-from HDF5_loader import create_dataloaders
+from dataset_loader import create_dataloaders
 from Configuration_System import (
     DataConfig as CSDataConfig,
     ValidationConfig as CSValConfig,
@@ -314,7 +314,7 @@ class ValidationRunner:
             except Exception:
                 # Fallback to direct file handler if QueueListener unavailable
                 logger.addHandler(fh)
-        # else: workers only attach QueueHandler in worker_init_fn (see HDF5_loader)
+        # else: workers only attach QueueHandler in worker_init_fn (see dataset_loader)
     
     def _load_model(self) -> Tuple[nn.Module, Optional[Dict]]:
         """Load model from checkpoint"""

--- a/vocabulary.py
+++ b/vocabulary.py
@@ -68,7 +68,7 @@ def _load_ignore_tags(ignore_file: Optional[Path] = None) -> Set[str]:
 class TagVocabulary:
     """Unified tag vocabulary manager with support for both training and inference.
     
-    This class combines functionality from both HDF5_loader.py and Inference_Engine.py
+    This class combines functionality from both dataset_loader.py and Inference_Engine.py
     to provide a single, comprehensive vocabulary implementation.
     
     Note: When using with PyTorch DataLoader in multiprocessing mode, ignored_tag_indices


### PR DESCRIPTION
## Summary
- Rename `HDF5_loader.py` to `dataset_loader.py` and remove biased sample fallback with proper cleanup of `ValidationIndex`
- Correct GradScaler initialization and adopt central config dataclasses with safe YAML overrides
- Fix AsymmetricFocalLoss weighting and flatten hyperparameter logging for TensorBoard

## Testing
- `python dataset_loader.py --help` *(fails: KeyboardInterrupt during heavy import)*
- `python train_direct.py --help` *(fails: KeyboardInterrupt during heavy import)*
- `python Inference_Engine.py --help` *(fails: KeyboardInterrupt during heavy import)*
- `python Monitor_log.py --help` *(fails: KeyboardInterrupt during heavy import)*
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68af7e4f7be483219655bb2d68126f44