### PR TITLE
Fix configuration loading and training state metric init

### DIFF
--- a/train_direct.py
+++ b/train_direct.py
@@ -14,6 +14,7 @@ from typing import Dict, Any, Optional
 import multiprocessing as mp
 import sys
 import random
+import queue
 from datetime import datetime
 import torch.distributed as dist
 from dataclasses import dataclass
@@ -702,7 +703,7 @@ def main():
     parser = create_config_parser()
     args = parser.parse_args()
     
-    config = load_config(args.config, args=args)
+    config = load_config(args.config)
 
     # Setup logging
     listener = setup_logging(

--- a/training_utils.py
+++ b/training_utils.py
@@ -134,7 +134,7 @@ class TrainingState:
     """Maintains complete training state"""
     epoch: int = 0
     global_step: int = 0
-    best_metric: float = float('inf')
+    best_metric: float = float('-inf')
     best_epoch: int = 0
     
     # Loss tracking


### PR DESCRIPTION
## Summary
- add missing queue import and correct config loader invocation
- initialize training state's best_metric with negative infinity for maximization metrics

## Testing
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`
- `python train_direct.py --help` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `python training_utils.py --help` *(fails: NameError: name 'LinearWarmupCosineAnnealingLR' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af80ae29948321943dac79690f9ac6