### PR TITLE
Default bf16 precision and add memory_format

### DIFF
--- a/Configuration_System.py
+++ b/Configuration_System.py
@@ -590,6 +590,8 @@ class LossConfig(BaseConfig):
 @dataclass
 class TrainingConfig(BaseConfig):
     """Training configuration"""
+    # Memory layout to unlock Tensor Core perf on Ampere+ (and Blackwell)
+    memory_format: str = "contiguous"  # or "channels_last"
     # Basic settings
     num_epochs: int = 100
     learning_rate: float = 1e-4
@@ -613,7 +615,7 @@ class TrainingConfig(BaseConfig):
     # Mixed precision
     use_amp: bool = True
     amp_opt_level: str = "O1"
-    amp_dtype: str = "float16"  # float16 or bfloat16
+    amp_dtype: str = "bfloat16"  # float16 or bfloat16
     enable_anomaly_detection: bool = False
 
     # Gradient clipping
@@ -730,7 +732,7 @@ class InferenceConfig(BaseConfig):
     """Inference configuration"""
     # Model
     model_path: Optional[str] = None
-    precision: str = "fp16"  # Options: "fp32", "fp16", "bf16"
+    precision: str = "bf16"  # Options: "fp32", "fp16", "bf16"
     compile_model: bool = False
     
     # Prediction


### PR DESCRIPTION
## Summary
- default AMP dtype to bfloat16
- expose memory_format option for TrainingConfig
- use bf16 precision by default in InferenceConfig

## Testing
- `python Configuration_System.py -h | head -n 20` (fails: Unknown command. Use 'generate' or 'validate')
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68af9f6965d883218143f8078f18cc19