### PR TITLE
chore: bump PyTorch stack for Blackwell GPUs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,11 +23,11 @@ scikit-learn==1.0.0
 scipy>=1.9
 seaborn==0.11.0
 tensorboard>=2.14,<2.17
-# Upgrade PyTorch stack for modern APIs and CUDA 12 support
-torch>=2.3
-torchvision>=0.18
+# Upgrade PyTorch stack for modern APIs and CUDA 12.8+ / SM_120 support
+torch>=2.7
+torchvision>=0.22
 # Ensure matching CUDA runtime when installing via pip
-pytorch-cuda>=12.1; platform_system=='Linux' and platform_machine=='x86_64'
+pytorch-cuda>=12.8; platform_system=='Linux' and platform_machine=='x86_64'
 tqdm==4.62.0
 uvicorn==0.15.0  # for API
 wandb==0.12.0  # optional


### PR DESCRIPTION
## Summary
- bump torch to 2.7+, torchvision to 0.22+, and pytorch-cuda to 12.8+ for CUDA 12.8/SM_120 support

## Testing
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`

------
https://chatgpt.com/codex/tasks/task_e_68afa3173b088321abd08a082cc64607