### PR TITLE
Add path utilities for safe file handling

### DIFF
--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from pathlib import Path
+import re
+
+DEFAULT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+def sanitize_identifier(s: str, pattern: re.Pattern[str] = DEFAULT_ID_RE) -> str:
+    if not pattern.fullmatch(s):
+        raise ValueError(f"Invalid identifier: {s!r}. Use only A–Z, a–z, 0–9, _ . -")
+    return s
+
+
+def safe_join(root: Path, *parts: str) -> Path:
+    root = root.resolve()
+    candidate = (root.joinpath(*parts)).resolve()
+    try:
+        candidate.relative_to(root)   # Py 3.9+
+    except ValueError:
+        raise ValueError(f"Path escapes dataset root: {candidate}")
+    return candidate
+
+
+def validate_image_path(
+    root: Path,
+    stem: str,
+    allowed_exts=(".jpg", ".jpeg", ".png", ".webp"),
+) -> Path:
+    stem = sanitize_identifier(Path(stem).stem)
+    # direct matches
+    for ext in allowed_exts:
+        p = safe_join(root, f"{stem}{ext}")
+        if p.exists():
+            return p
+    # case-insensitive fallback
+    try:
+        lower_map = {f.name.lower(): f for f in root.iterdir() if f.is_file()}
+        for ext in allowed_exts:
+            alt = lower_map.get(f"{stem}{ext}".lower())
+            if alt:
+                return safe_join(root, alt.name)
+    except FileNotFoundError:
+        pass
+    raise FileNotFoundError(f"Image not found under {root}: {stem}")


### PR DESCRIPTION
## Summary
- introduce `sanitize_identifier` to validate dataset identifiers
- add `safe_join` to prevent directory traversal
- implement `validate_image_path` for case-insensitive image lookup

## Testing
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68afbb6321a88321beb47c388a8a2f0e