### PR TITLE
refactor: centralize path helpers

### DIFF
--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -1,0 +1,36 @@
+"""Common path utilities for dataset handling."""
+
+from pathlib import Path
+
+
+def safe_join(root: Path, rel: str) -> Path:
+    """Join root and rel, raising if the result escapes the dataset root."""
+    p = (root / rel).resolve()
+    root_resolved = root.resolve()
+    if not str(p).startswith(str(root_resolved)):
+        raise ValueError(f"Path escapes dataset root: {rel}")
+    return p
+
+
+def validate_image_path(root: Path, name: str,
+                         allowed_exts=(".jpg", ".jpeg", ".png", ".webp")) -> Path:
+    """Resolve and validate an image path from a base name.
+
+    Searches for a file with any of the allowed extensions (case-insensitive)
+    relative to ``root``.
+    """
+    base = Path(name)
+    allowed = [ext.lower() for ext in allowed_exts]
+    for ext in allowed:
+        candidate = safe_join(root, str(base.with_suffix(ext)))
+        if candidate.exists():
+            return candidate
+        # case-insensitive search
+        try:
+            files = {f.name.lower(): f for f in candidate.parent.iterdir() if f.is_file()}
+        except FileNotFoundError:
+            continue
+        alt = files.get(candidate.name.lower())
+        if alt and alt.exists():
+            return alt
+    raise FileNotFoundError(f"Image not found: {base}")


### PR DESCRIPTION
## Summary
- add shared `path_utils` with canonical `safe_join` and `validate_image_path`
- reuse centralized helpers in `metadata_ingestion`
- ensure image path validation preserves subdirectory info

## Testing
- `python - <<'PY'
from pathlib import Path
import tempfile
from utils import metadata_ingestion as m
from utils import path_utils as pu

with tempfile.TemporaryDirectory() as d:
    root = Path(d)
    sub = root / 'sub'
    sub.mkdir()
    (sub/'img.JPG').write_text('data')
    assert m.safe_join(root, 'sub/img.JPG') == pu.safe_join(root, 'sub/img.JPG')
    assert m.validate_image_path(root, 'sub/img.JPG') == sub/'img.JPG'
print('ok')
PY`
- `python - <<'PY'
import subprocess, compileall, pathlib
files = subprocess.check_output(['git','ls-files','*.py']).decode().splitlines()
for f in files:
    compileall.compile_file(f, force=True)
print('compiled', len(files), 'files')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68afbb66e3e48321a2ce2a469f89f208