### PR TITLE
Use safetensors-based cache encoding

### DIFF
--- a/cache_codec.py
+++ b/cache_codec.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+import os
+import hmac
+import hashlib
+from typing import Optional
+
+import torch
+from safetensors.torch import save, load
+
+# Optional HMAC key for integrity checks
+_HMAC_KEY = os.environ.get("CACHE_CODEC_HMAC_KEY")
+_DIGEST_SIZE = hashlib.sha256().digest_size
+
+
+def _resolve_key(key: Optional[bytes | str]) -> Optional[bytes]:
+    if key is None:
+        key = _HMAC_KEY
+    if key is None:
+        return None
+    if isinstance(key, str):
+        return key.encode("utf-8")
+    return key
+
+
+def encode_tensor(t: torch.Tensor, key: Optional[bytes | str] = None) -> bytes:
+    """Serialize a tensor to bytes using safetensors with optional HMAC."""
+    data = save({"t": t.contiguous()})
+    k = _resolve_key(key)
+    if k:
+        digest = hmac.new(k, data, "sha256").digest()
+        data = digest + data
+    return data
+
+
+def decode_tensor(b: bytes, key: Optional[bytes | str] = None) -> torch.Tensor:
+    """Deserialize bytes back into a tensor, verifying HMAC if present."""
+    k = _resolve_key(key)
+    data = b
+    if k:
+        digest, payload = data[:_DIGEST_SIZE], data[_DIGEST_SIZE:]
+        expected = hmac.new(k, payload, "sha256").digest()
+        if not hmac.compare_digest(digest, expected):
+            raise ValueError("HMAC verification failed")
+        data = payload
+    tensors = load(data)
+    return tensors["t"]
+
+
+__all__ = ["encode_tensor", "decode_tensor"]

--- a/l2_cache.py
+++ b/l2_cache.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
-import os, io, time, atexit, pickle, signal, queue
+import os, time, atexit, signal, queue
 import multiprocessing as mp
 from typing import Optional, Tuple
 import lmdb
 import torch
+from cache_codec import encode_tensor as _tensor_to_bytes, decode_tensor as _tensor_from_bytes
 
-# --- Serialization helpers (fast, torch-native) ---
-def _tensor_to_bytes(t: torch.Tensor) -> bytes:
-    buf = io.BytesIO()
-    torch.save(t.contiguous(), buf)
-    return buf.getvalue()
-
-def _tensor_from_bytes(b: bytes) -> torch.Tensor:
-    return torch.load(io.BytesIO(b), map_location="cpu")
+# Serialization now lives in cache_codec.py (safetensors + optional HMAC)
 
 # --- Read-only per-process cache handle ---
 class LMDBReader:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ protobuf>=3.20.3,<5
 werkzeug>=2.2,<5
 scikit-learn==1.0.0
 scipy>=1.9
+safetensors>=0.4.2
 seaborn==0.11.0
 tensorboard>=2.14,<2.17
 # Upgrade PyTorch stack for modern APIs and CUDA 12.8+ / SM_120 support


### PR DESCRIPTION
## Summary
- replace pickle tensor serialization with safetensors-based helpers in `cache_codec`
- update `l2_cache` to use new codec and drop inline helpers
- declare safetensors dependency

## Testing
- `pip install safetensors`
- `pip install lmdb==1.3.0`
- `pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu`
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`
- `python l2_cache.py --help`
- `python cache_codec.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68afbbabe9388321b8bed1c096b828b8