### PR TITLE
Improve ONNX export safety and dependency versions

### DIFF
--- a/configs/unified_config.yaml
+++ b/configs/unified_config.yaml
@@ -285,7 +285,7 @@ inference:
 # Export Configuration (from export_config.yaml)
 export:
   export_format: "onnx"
-  opset_version: 18
+  opset_version: 19
   export_params: true
   do_constant_folding: true
   dynamic_batch_size: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ lmdb==1.3.0
 matplotlib==3.4.0
 networkx==2.6.0  # optional
 numpy>=1.23,<3
-onnx==1.11.0
-onnxruntime==1.10.0
+onnx>=1.16.0,<2
+onnxruntime-gpu>=1.20.0
 onnxsim==0.4.36
 opencv-python>=4.8
 pandas>=1.5
@@ -17,7 +17,7 @@ psutil==5.8.0
 python-multipart==0.0.5  # for API
 pyyaml==5.4.0
 requests>=2.28
-protobuf>=3.20.3,<5
+protobuf>=4.25.3,<6
 werkzeug>=2.2,<5
 scikit-learn==1.0.0
 scipy>=1.9


### PR DESCRIPTION
## Summary
- add ONNX and onnxruntime version checks with minimum opset 18
- load checkpoints via `safe_load_checkpoint`
- bump default opset to 19 and update ONNX/ORT/protobuf requirements

## Testing
- `python ONNX_Export.py --help`
- `git ls-files '*.py' | xargs -I {} python -m py_compile "{}"`


------
https://chatgpt.com/codex/tasks/task_e_68afc32b68d0832197fd4de685afe66f